### PR TITLE
fix(tts): per-session state + reject TTS when no active stream

### DIFF
--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -291,16 +291,24 @@ class DesktopMateChannel(BaseChannel):
     def is_tts_enabled_for_current_stream(self) -> bool:
         """Public accessor for :class:`LazyChannelTTSSink`.
 
-        Returns True whenever we can't identify the current stream —
-        that's a "don't skip synthesis" signal so we default to useful
-        work when routing state hasn't caught up yet.
+        Returns ``False`` whenever no desktop_mate stream is currently
+        registered. This is the gate that keeps TTSHook from synthesising
+        for turns running on *other* channels (e.g. the Phase-5 idle
+        watcher firing through ``channel=cli``): those turns never set
+        ``_current_stream_id`` on this channel, so we correctly decline
+        to emit audio for them.
+
+        The previous default (``True`` when no stream) was a holdover from
+        a single-channel assumption that Phase 5 broke. See
+        migration-todo §3-D (Scenario C regression) and the tts.py
+        "Per-session state" section.
         """
         stream_id = self._current_stream_id
         if stream_id is None:
-            return True
+            return False
         info = self._streams.get(stream_id)
         if info is None:
-            return True
+            return False
         chat_id, _ = info
         return self._tts_enabled_for_chat(chat_id)
 

--- a/src/nanobot_runtime/hooks/tts.py
+++ b/src/nanobot_runtime/hooks/tts.py
@@ -15,12 +15,26 @@ call, matching DMP's single-turn semantics.
 Dependencies are injected as protocols so the hook is unit-testable without
 real TTS infra. Real implementations (fast_bunkai chunker, IrodoriTTS
 synth, emotion-motion YAML map) are provided by separate modules.
+
+Per-session state (since 2026-04-22)
+------------------------------------
+nanobot's AgentLoop runs up to ``NANOBOT_MAX_CONCURRENT_REQUESTS`` turns in
+parallel and shares a single ``_extra_hooks`` list across all sessions/
+channels, so one TTSHook instance sees deltas from every concurrent turn
+interleaved. The hook therefore keeps a **per-session** chunker/sequence/
+pending-tasks state bundle keyed on ``AgentHookContext.session_key``
+(added upstream in the nanobot fork). Turns on non-desktop channels (e.g.
+the idle-watcher firing through ``channel=cli``) still drive ``on_stream``,
+but the sink's ``is_enabled()`` gate returns ``False`` for them, so their
+sentences never consume a sequence number. When ``session_key`` is ``None``
+(caller didn't supply one — stale nanobot, or a test) the hook falls back
+to a shared ``_default`` state bucket and emits a warning once.
 """
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from loguru import logger
 from nanobot.agent.hook import AgentHook, AgentHookContext
@@ -75,6 +89,21 @@ class TTSSink(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# Per-session state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _SessionState:
+    chunker: SentenceChunker
+    sequence: int = 0
+    pending: list[asyncio.Task[None]] = field(default_factory=list)
+
+
+_FALLBACK_SESSION_KEY = "__tts_hook_default__"
+
+
+# ---------------------------------------------------------------------------
 # Hook
 # ---------------------------------------------------------------------------
 
@@ -83,7 +112,7 @@ class TTSHook(AgentHook):
     def __init__(
         self,
         *,
-        chunker: SentenceChunker,
+        chunker_factory: Callable[[], SentenceChunker],
         preprocessor: TextPreprocessor,
         emotion_mapper: EmotionMapper,
         synthesizer: TTSSynthesizer,
@@ -91,14 +120,14 @@ class TTSHook(AgentHook):
         barrier_timeout_seconds: float = 30.0,
     ) -> None:
         super().__init__()
-        self._chunker = chunker
+        self._chunker_factory = chunker_factory
         self._preprocessor = preprocessor
         self._emotion_mapper = emotion_mapper
         self._synthesizer = synthesizer
         self._sink = sink
         self._barrier_timeout = barrier_timeout_seconds
-        self._sequence = 0
-        self._pending: list[asyncio.Task[None]] = []
+        self._states: dict[str, _SessionState] = {}
+        self._fallback_warned = False
 
     def wants_streaming(self) -> bool:
         return True
@@ -106,11 +135,9 @@ class TTSHook(AgentHook):
     async def on_stream(self, context: AgentHookContext, delta: str) -> None:
         if not delta:
             return
-        # First delta of a new turn: reset sequence counter.
-        if context.iteration == 0 and self._sequence and not self._pending:
-            self._sequence = 0
-        for sentence in self._chunker.feed(delta):
-            self._dispatch_sentence(sentence)
+        state = self._state_for(context)
+        for sentence in state.chunker.feed(delta):
+            self._dispatch_sentence(state, sentence)
 
     async def on_stream_end(
         self, context: AgentHookContext, *, resuming: bool
@@ -121,36 +148,66 @@ class TTSHook(AgentHook):
         if resuming:
             return
 
-        remainder = self._chunker.flush()
+        key = self._session_key(context)
+        state = self._states.get(key)
+        if state is None:
+            # Turn produced no deltas for this session — nothing to drain.
+            return
+
+        remainder = state.chunker.flush()
         if remainder:
-            self._dispatch_sentence(remainder)
+            self._dispatch_sentence(state, remainder)
 
         # TTS Barrier: block until every pending synth task settles, so the
         # caller (channel) can emit stream_end immediately after this returns.
-        if self._pending:
+        if state.pending:
             try:
                 await asyncio.wait_for(
-                    asyncio.gather(*self._pending, return_exceptions=True),
+                    asyncio.gather(*state.pending, return_exceptions=True),
                     timeout=self._barrier_timeout,
                 )
             except TimeoutError:
                 logger.warning(
-                    "TTS Barrier timeout ({}s) — {} tasks still pending; cancelling.",
+                    "TTS Barrier timeout ({}s) — {} tasks still pending; "
+                    "cancelling. (session={})",
                     self._barrier_timeout,
-                    sum(1 for t in self._pending if not t.done()),
+                    sum(1 for t in state.pending if not t.done()),
+                    key,
                 )
-                for t in self._pending:
+                for t in state.pending:
                     if not t.done():
                         t.cancel()
-            self._pending.clear()
 
-        self._sequence = 0
+        # Turn fully wrapped — drop the per-session bucket so the next turn
+        # for the same session starts clean (sequence back to 0, fresh chunker).
+        self._states.pop(key, None)
 
     # ------------------------------------------------------------------
     # internals
     # ------------------------------------------------------------------
 
-    def _dispatch_sentence(self, sentence: str) -> None:
+    def _session_key(self, context: AgentHookContext) -> str:
+        key = getattr(context, "session_key", None)
+        if key is None:
+            if not self._fallback_warned:
+                logger.warning(
+                    "TTSHook: AgentHookContext.session_key is None — falling "
+                    "back to a shared default bucket. Update the nanobot "
+                    "dependency so concurrent turns don't share TTS state."
+                )
+                self._fallback_warned = True
+            return _FALLBACK_SESSION_KEY
+        return key
+
+    def _state_for(self, context: AgentHookContext) -> _SessionState:
+        key = self._session_key(context)
+        state = self._states.get(key)
+        if state is None:
+            state = _SessionState(chunker=self._chunker_factory())
+            self._states[key] = state
+        return state
+
+    def _dispatch_sentence(self, state: _SessionState, sentence: str) -> None:
         text, emotion = self._preprocessor.process(sentence)
         if not text or not any(ch.isalnum() for ch in text):
             return
@@ -160,10 +217,10 @@ class TTSHook(AgentHook):
         is_enabled = getattr(self._sink, "is_enabled", None)
         if callable(is_enabled) and not is_enabled():
             return
-        sequence = self._sequence
-        self._sequence += 1
+        sequence = state.sequence
+        state.sequence += 1
         task = asyncio.create_task(self._synth_and_emit(text, emotion, sequence))
-        self._pending.append(task)
+        state.pending.append(task)
 
     async def _synth_and_emit(
         self, text: str, emotion: str | None, sequence: int

--- a/tests/channels/test_tts_sink_wiring.py
+++ b/tests/channels/test_tts_sink_wiring.py
@@ -101,11 +101,19 @@ def test_channel_reports_tts_enabled_via_current_stream():
     assert channel.is_tts_enabled_for_current_stream() is True
 
 
-def test_channel_tts_enabled_defaults_when_no_active_stream():
-    """If nothing is routed yet, return True (safe default — hook will
-    have something to ask about when the first delta arrives anyway)."""
+def test_channel_tts_enabled_is_false_when_no_active_stream():
+    """If no desktop_mate stream is currently registered, return False so
+    TTSHook does not synthesise for turns that belong to a different
+    channel (e.g. the idle-watcher firing through ``channel=cli``).
+
+    Previously the default was True with the rationale "hook will have
+    something to ask about when the first delta arrives anyway". Phase 5
+    broke that assumption by introducing cross-channel concurrency — see
+    ``src/.../channels/desktop_mate.py::is_tts_enabled_for_current_stream``
+    for the full context.
+    """
     channel = DesktopMateChannel(DesktopMateConfig(), _FakeBus())
-    assert channel.is_tts_enabled_for_current_stream() is True
+    assert channel.is_tts_enabled_for_current_stream() is False
 
 
 async def test_lazy_sink_is_enabled_forwards_to_channel():

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -49,12 +49,12 @@ YURI_E2E_TIMEOUT=40 pytest tests/e2e/ -m e2e
 | C — long response | SentenceChunker produces ≥2 `tts_chunk`s with increasing `sequence` |
 | D — emotion emoji | stripped from `delta.text`; preserved in `tts_chunk.text`; `emotion` tag set |
 | E — parallel chats | two concurrent WS connections receive distinct `chat_id`s, no cross-talk |
+| F — reconnect | close WS, new WS with same `chat_id` → agent recalls a nonce spoken in the prior connection (SessionManager JSONL reload) |
 | G — `?tts=0` URL override | client receives no `tts_chunk` **and** gateway log shows zero `IrodoriClient.synthesize:` lines |
 | H — inbound `tts_enabled:false` | same as G |
 
-Scenarios F (reconnect across a new WS) and I (default-on guard) are
-covered by the in-process regression suite only — reconnect needs a
-dedicated nanobot session-TTL harness.
+Scenario I (default-on guard) is covered by the in-process regression
+suite only; on live it is equivalent to A.
 
 ## Diagnostics
 

--- a/tests/e2e/test_live_scenarios.py
+++ b/tests/e2e/test_live_scenarios.py
@@ -7,19 +7,19 @@ the wire contract deterministically — this suite catches integration
 bugs the fakes cannot see (nanobot AgentLoop ordering, real TTS
 chunking timing, session management, etc.).
 
-Coverage mapping to migration-todo §3-D (scenarios A/B/C/D/E/G/H):
+Coverage mapping to migration-todo §3-D (scenarios A/B/C/D/E/F/G/H):
 
 * A — new session full lifecycle
 * B — resumed session with supplied chat_id
 * C — long response → 3+ tts_chunks
 * D — emotion emoji: stripped in delta, preserved in tts_chunk.text
 * E — parallel chat_id isolation (two WS connections)
+* F — reconnect: WS socket close → new socket, same chat_id → history preserved
 * G — URL ``?tts=0`` override → no synthesize(), no tts_chunk
 * H — inbound ``tts_enabled: false`` → no synthesize(), no tts_chunk
 
-F (reconnect after disconnect) and I (default-on guard) are covered by
-the in-process suite; the nanobot session-TTL behaviour would need a
-separate dedicated harness.
+Scenario I (default-on guard) is covered by the in-process suite only
+(it is equivalent to A once the flag defaults are set).
 
 Run: ``pytest tests/e2e/ -m e2e`` (not collected by default).
 """
@@ -200,6 +200,91 @@ async def test_e_parallel_chats_are_isolated(gateway, live_client) -> None:
     assert len(a_ids) == 1, a_ids
     assert len(b_ids) == 1, b_ids
     assert a_ids != b_ids, f"clients share chat_id {a_ids}; cross-talk"
+
+
+# ---------------------------------------------------------------------------
+# Scenario F — reconnect after WS close: same chat_id → history preserved
+# ---------------------------------------------------------------------------
+
+
+async def test_f_reconnect_preserves_session_history(gateway, live_client) -> None:
+    """Client A establishes a fact, closes its WebSocket, then client B
+    connects on a fresh socket with the same ``chat_id`` and asks for the
+    fact back. The agent must reply with the fact, which proves:
+
+    1. ``SessionManager`` persisted the turn to JSONL and reloaded it on
+       reconnect (the route nanobot takes only when the connection is
+       genuinely new — the in-process suite reuses one connection so it
+       cannot exercise this path).
+    2. The per-session ``chat_id`` → history injection still works when
+       no in-memory connection kept the session warm.
+
+    The "fact" is a random nonce so prior LTM content cannot cause a
+    false positive, and LTM is sidestepped by phrasing the recall prompt
+    to reference "방금" (just now) which biases the model toward recent
+    conversation rather than long-term memory.
+    """
+    import uuid
+
+    chat_id = f"e2e-F-{uuid.uuid4().hex[:8]}"
+    # 4-digit number. Unlikely to appear in LTM for this user, unlikely
+    # to be guessed by the model without session context.
+    secret = f"{uuid.uuid4().int % 9000 + 1000}"
+
+    # --- Connection 1: teach the fact ---
+    client_a = await live_client(client_id="e2e-F-first")
+    await client_a.wait_for_event("ready", timeout=5.0)
+    await run_turn_and_drain(
+        client_a,
+        {
+            "type": "message",
+            "chat_id": chat_id,
+            "content": f"내 비밀 번호는 {secret} 이야. 이 숫자를 기억해둬.",
+            "tts_enabled": False,
+        },
+        stream_end_timeout=45.0,
+        drain_seconds=1.0,
+    )
+    await client_a.close()
+    # Small gap so the JSONL writer flushes and the WS handler cleans up
+    # its per-connection subscriptions before the second client lands.
+    await asyncio.sleep(1.0)
+
+    # --- Connection 2: fresh socket, same chat_id ---
+    client_b = await live_client(client_id="e2e-F-second")
+    await client_b.wait_for_event("ready", timeout=5.0)
+    await run_turn_and_drain(
+        client_b,
+        {
+            "type": "message",
+            "chat_id": chat_id,
+            "content": "방금 내가 알려준 비밀 번호가 뭐였지? 숫자만 답해.",
+            "tts_enabled": False,
+        },
+        stream_end_timeout=45.0,
+        drain_seconds=1.0,
+    )
+
+    recalled = "".join(
+        f.get("text", "") for f in client_b.frames if f.get("event") == "delta"
+    )
+    assert secret in recalled, (
+        f"Agent did not recall fact {secret!r} from the prior (closed) "
+        f"WS connection under chat_id={chat_id}. Second-turn reply: "
+        f"{recalled!r}"
+    )
+
+    # Both connections must have seen frames only for this chat_id.
+    a_ids = {
+        f.get("chat_id") for f in client_a.frames
+        if "chat_id" in f and f.get("event") != "ready"
+    }
+    b_ids = {
+        f.get("chat_id") for f in client_b.frames
+        if "chat_id" in f and f.get("event") != "ready"
+    }
+    assert a_ids == {chat_id}, a_ids
+    assert b_ids == {chat_id}, b_ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/harness.py
+++ b/tests/regression/harness.py
@@ -162,7 +162,11 @@ class Harness:
         # Reset hook sequence at a turn boundary (iteration==0 + no pending).
         from nanobot.agent.hook import AgentHookContext
 
-        ctx = AgentHookContext(iteration=0, messages=[])
+        ctx = AgentHookContext(
+            iteration=0,
+            messages=[],
+            session_key=f"desktop_mate:{chat_id}",
+        )
 
         for delta in deltas:
             # Channel dispatches the delta first so stream routing state is
@@ -225,7 +229,7 @@ def build_harness(
     }
     synth = RecordingSynthesizer()
     hook = TTSHook(
-        chunker=SentenceChunker(min_chunk_length=min_chunk_length),
+        chunker_factory=lambda: SentenceChunker(min_chunk_length=min_chunk_length),
         preprocessor=Preprocessor(known_emojis=frozenset(emojis)),
         emotion_mapper=EmotionMapper(emotion_map),
         synthesizer=synth,

--- a/tests/test_tts_hook.py
+++ b/tests/test_tts_hook.py
@@ -101,7 +101,7 @@ def _make_hook(
     sink = _FakeSink()
     synth = _FakeSynthesizer(latency=latency, fail_on=fail_on)
     hook = TTSHook(
-        chunker=_FakeChunker(),
+        chunker_factory=_FakeChunker,
         preprocessor=_FakePreprocessor(),
         emotion_mapper=_FakeEmotionMapper(),
         synthesizer=synth,
@@ -110,8 +110,10 @@ def _make_hook(
     return hook, sink, synth
 
 
-def _ctx(iteration: int = 0) -> AgentHookContext:
-    return AgentHookContext(iteration=iteration, messages=[])
+def _ctx(iteration: int = 0, session_key: str = "test-session") -> AgentHookContext:
+    return AgentHookContext(
+        iteration=iteration, messages=[], session_key=session_key
+    )
 
 
 # --------------------------------------------------------------------------
@@ -311,7 +313,7 @@ async def test_is_enabled_false_skips_synthesis_entirely() -> None:
     sink = _FakeSinkWithEnableFlag(enabled=False)
     synth = _FakeSynthesizer()
     hook = TTSHook(
-        chunker=_FakeChunker(),
+        chunker_factory=_FakeChunker,
         preprocessor=_FakePreprocessor(),
         emotion_mapper=_FakeEmotionMapper(),
         synthesizer=synth,
@@ -329,7 +331,7 @@ async def test_is_enabled_true_keeps_default_behaviour() -> None:
     sink = _FakeSinkWithEnableFlag(enabled=True)
     synth = _FakeSynthesizer()
     hook = TTSHook(
-        chunker=_FakeChunker(),
+        chunker_factory=_FakeChunker,
         preprocessor=_FakePreprocessor(),
         emotion_mapper=_FakeEmotionMapper(),
         synthesizer=synth,


### PR DESCRIPTION
## Summary

- **Fixes Scenario C regression** introduced by Phase 5 idle-watcher: its `channel=cli` turns were bumping the shared `TTSHook._sequence` so desktop_mate turns started at `seq=1` instead of `0`, and stray synth tasks hit `send_tts_chunk` with no active stream.
- **Per-session TTSHook state** keyed on `AgentHookContext.session_key` (added in the paired upstream PR — nanobot `feat/hook-context-session-key`). Each turn now gets its own `SentenceChunker` from a factory, so buffers never cross sessions and concurrent turns (nanobot default max 3) no longer corrupt one another.
- **`DesktopMateChannel.is_tts_enabled_for_current_stream()` returns False when no stream is registered.** Turns belonging to other channels never set `_current_stream_id`, so this is the gate that prevents the hook from synthesising for them.

Depends on the forked nanobot having the `session_key` field; falls back (with a one-shot warning) to a shared bucket when absent, so the runtime still boots against stock nanobot.

## Test plan

- [x] `pytest` — 157 unit/integration passed
- [x] `pytest tests/e2e/ -m e2e` — **8/8 passed** (previously C failed with `seqs=[1, 2]`)
- [x] yuri workspace smoke: gateway starts and serves messages, TTS chunks `seq=0,1,...` per turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)