### PR TITLE
chore: use forked nanobot-ai from GitHub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
     "pytest-httpx>=0.30",
 ]
 
+[tool.uv.sources]
+nanobot-ai = { git = "https://github.com/yw0nam/nanobot", branch = "develop" }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- `nanobot-ai` 의존성을 PyPI 공식 버전 대신 포크(`https://github.com/yw0nam/nanobot`, `develop` 브랜치)에서 받도록 변경
- 포크에 추가된 `AgentHookContext.session_key` 필드가 필요 — `TTSHook`의 per-session TTS 상태 격리에 사용됨
- `[tool.uv.sources]`로 고정하므로 어느 워크스페이스에서 클론해도 `uv sync`만으로 포크 버전 설치됨

## Test plan
- [x] `uv sync` 후 `uv run pytest` → 157 passed 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)