### PR TITLE
feat(channels): mirror nanobot session REST routes in DesktopMateChannel

### DIFF
--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -24,6 +24,7 @@ are explicitly out of scope and can layer on later.
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -32,6 +33,8 @@ from urllib.parse import parse_qs, urlparse
 
 from loguru import logger
 from pydantic import BaseModel, ValidationError
+from websockets.http11 import Request as WsRequest
+from websockets.http11 import Response
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
@@ -46,6 +49,15 @@ from nanobot_runtime.channels.desktop_mate_protocol import (
     StreamStartFrame,
     TTSChunkFrame,
     parse_inbound,
+)
+from nanobot_runtime.channels.desktop_mate_rest import (
+    bearer_token,
+    decode_api_key,
+    http_error,
+    http_json_response,
+    is_websocket_upgrade,
+    parse_request_path,
+    query_first,
 )
 from nanobot_runtime.hooks.tts import TTSChunk
 
@@ -200,10 +212,15 @@ class DesktopMateChannel(BaseChannel):
         bus: MessageBus,
         *,
         emotion_emojis: set[str] | None = None,
+        session_manager: Any | None = None,
     ) -> None:
         coerced = _coerce_config(config)
         super().__init__(coerced, bus)
         self.config: DesktopMateConfig = coerced
+        # Injected by the gateway's ChannelManager monkey-patch; used by the
+        # REST routes below. ``None`` is tolerated so unit tests can construct
+        # the channel in isolation — the routes 503 in that case.
+        self._session_manager = session_manager
         global _LATEST_CHANNEL
         _LATEST_CHANNEL = self
         # Emoji-stripping set: explicit kwarg (tests) wins, else load from
@@ -473,6 +490,99 @@ class DesktopMateChannel(BaseChannel):
             ),
         )
 
+    # -- REST surface ------------------------------------------------------
+
+    _SESSION_KEY_PREFIX = "desktop_mate:"
+
+    async def _dispatch_http(self, connection: Any, request: WsRequest) -> Any:
+        """Route an inbound HTTP request to a REST handler or fall through to WS.
+
+        Returning ``None`` lets the ``websockets`` library proceed with the
+        WebSocket handshake; returning a :class:`Response` short-circuits
+        with an HTTP reply.
+        """
+        got, _query = parse_request_path(request.path)
+
+        if got == "/api/sessions":
+            return self._handle_sessions_list(request)
+
+        m = re.match(r"^/api/sessions/([^/]+)/messages$", got)
+        if m:
+            return self._handle_session_messages(request, m.group(1))
+
+        # websockets' HTTP parser only supports GET, so delete is path-folded.
+        m = re.match(r"^/api/sessions/([^/]+)/delete$", got)
+        if m:
+            return self._handle_session_delete(request, m.group(1))
+
+        # Let the WS handshake path through.
+        expected_ws = self.config.path.rstrip("/") or "/"
+        if got == expected_ws and is_websocket_upgrade(request):
+            return None
+
+        return http_error(404, "Not Found")
+
+    def _check_rest_token(self, request: WsRequest) -> bool:
+        """Validate the REST request against the channel's static token.
+
+        Accepts ``Authorization: Bearer <token>`` header or ``?token=<token>``
+        query string. When no token is configured (dev / loopback), every
+        request is allowed — mirroring ``_authorize_token``.
+        """
+        expected = (self.config.token or "").strip()
+        if not expected:
+            return True
+        _, query = parse_request_path(request.path)
+        supplied = bearer_token(request.headers) or query_first(query, "token")
+        return supplied is not None and supplied == expected
+
+    def _is_desktop_mate_key(self, key: str) -> bool:
+        return key.startswith(self._SESSION_KEY_PREFIX)
+
+    def _handle_sessions_list(self, request: WsRequest) -> Response:
+        if not self._check_rest_token(request):
+            return http_error(401, "Unauthorized")
+        if self._session_manager is None:
+            return http_error(503, "session manager unavailable")
+        sessions = self._session_manager.list_sessions()
+        # Filter to our own channel's sessions and strip absolute paths —
+        # the FE doesn't need filesystem layout.
+        cleaned = [
+            {k: v for k, v in s.items() if k != "path"}
+            for s in sessions
+            if isinstance(s.get("key"), str)
+            and self._is_desktop_mate_key(s["key"])
+        ]
+        return http_json_response({"sessions": cleaned})
+
+    def _handle_session_messages(self, request: WsRequest, key: str) -> Response:
+        if not self._check_rest_token(request):
+            return http_error(401, "Unauthorized")
+        if self._session_manager is None:
+            return http_error(503, "session manager unavailable")
+        decoded = decode_api_key(key)
+        if decoded is None:
+            return http_error(400, "invalid session key")
+        if not self._is_desktop_mate_key(decoded):
+            return http_error(404, "session not found")
+        data = self._session_manager.read_session_file(decoded)
+        if data is None:
+            return http_error(404, "session not found")
+        return http_json_response(data)
+
+    def _handle_session_delete(self, request: WsRequest, key: str) -> Response:
+        if not self._check_rest_token(request):
+            return http_error(401, "Unauthorized")
+        if self._session_manager is None:
+            return http_error(503, "session manager unavailable")
+        decoded = decode_api_key(key)
+        if decoded is None:
+            return http_error(400, "invalid session key")
+        if not self._is_desktop_mate_key(decoded):
+            return http_error(404, "session not found")
+        deleted = self._session_manager.delete_session(decoded)
+        return http_json_response({"deleted": bool(deleted)})
+
     # -- Auth / handshake --------------------------------------------------
 
     def _authorize_token(self, supplied: str | None) -> bool:
@@ -605,11 +715,15 @@ class DesktopMateChannel(BaseChannel):
             self.config.path,
         )
 
+        async def process_request(connection: Any, request: WsRequest) -> Any:
+            return await self._dispatch_http(connection, request)
+
         async def runner() -> None:
             async with serve(
                 handler,
                 self.config.host,
                 self.config.port,
+                process_request=process_request,
                 ping_interval=self.config.ping_interval_s,
                 ping_timeout=self.config.ping_timeout_s,
                 max_size=self.config.max_message_bytes,

--- a/src/nanobot_runtime/channels/desktop_mate_rest.py
+++ b/src/nanobot_runtime/channels/desktop_mate_rest.py
@@ -1,0 +1,104 @@
+"""HTTP helpers for :class:`DesktopMateChannel`'s REST surface.
+
+Mirrors nanobot's ``WebSocketChannel`` session routes so the FE's existing
+STM sidebar (list / history / delete) keeps working against our custom
+channel. We intentionally copy the helpers rather than importing them
+from ``nanobot.channels.websocket`` — those symbols are private and the
+upstream module is large; pinning to them would fragile-couple us to
+nanobot internals beyond what ``gateway.py`` already does.
+
+Auth model is intentionally simpler than nanobot's TTL-bound token pool:
+we reuse the static ``?token=`` used for the WebSocket handshake.
+Rotating tokens can layer on later without changing the REST shape.
+"""
+from __future__ import annotations
+
+import email.utils
+import http
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+from websockets.datastructures import Headers
+from websockets.http11 import Request as WsRequest
+from websockets.http11 import Response
+
+
+# Session keys look like ``desktop_mate:<chat_id>``. Keep permissive enough
+# for hyphenated UUIDs and colon-separated namespacing, but tight enough
+# to rule out path traversal / quote injection.
+_API_KEY_RE = re.compile(r"^[A-Za-z0-9_:.-]{1,128}$")
+
+
+def _strip_trailing_slash(path: str) -> str:
+    if len(path) > 1 and path.endswith("/"):
+        return path[:-1]
+    return path
+
+
+def parse_request_path(path_with_query: str) -> tuple[str, dict[str, list[str]]]:
+    """Split a raw request path into ``(normalized_path, query_dict)``."""
+    parsed = urlparse("ws://x" + path_with_query)
+    path = _strip_trailing_slash(parsed.path or "/")
+    return path, parse_qs(parsed.query)
+
+
+def query_first(query: dict[str, list[str]], key: str) -> str | None:
+    values = query.get(key)
+    return values[0] if values else None
+
+
+def bearer_token(headers: Any) -> str | None:
+    """Extract a ``Authorization: Bearer <token>`` header value."""
+    auth = headers.get("Authorization") or headers.get("authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth[7:].strip() or None
+    return None
+
+
+def is_websocket_upgrade(request: WsRequest) -> bool:
+    """Return True iff the request is an actual WS upgrade handshake."""
+    upgrade = request.headers.get("Upgrade") or request.headers.get("upgrade")
+    connection = request.headers.get("Connection") or request.headers.get("connection")
+    if not upgrade or "websocket" not in upgrade.lower():
+        return False
+    if not connection or "upgrade" not in connection.lower():
+        return False
+    return True
+
+
+def decode_api_key(raw_key: str) -> str | None:
+    """URL-decode a session key from the path and validate it."""
+    key = unquote(raw_key)
+    if _API_KEY_RE.match(key) is None:
+        return None
+    return key
+
+
+def http_response(
+    body: bytes,
+    *,
+    status: int = 200,
+    content_type: str = "text/plain; charset=utf-8",
+) -> Response:
+    headers = [
+        ("Date", email.utils.formatdate(usegmt=True)),
+        ("Connection", "close"),
+        ("Content-Length", str(len(body))),
+        ("Content-Type", content_type),
+    ]
+    reason = http.HTTPStatus(status).phrase
+    return Response(status, reason, Headers(headers), body)
+
+
+def http_json_response(data: dict[str, Any], *, status: int = 200) -> Response:
+    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    return http_response(
+        body, status=status, content_type="application/json; charset=utf-8"
+    )
+
+
+def http_error(status: int, message: str | None = None) -> Response:
+    body = (message or http.HTTPStatus(status).phrase).encode("utf-8")
+    return http_response(body, status=status)

--- a/src/nanobot_runtime/gateway.py
+++ b/src/nanobot_runtime/gateway.py
@@ -10,6 +10,7 @@ Pinned to nanobot 0.1.5.x — version drift fails loud at startup.
 """
 from __future__ import annotations
 
+import inspect
 import os
 from typing import Any, Callable
 
@@ -17,6 +18,7 @@ import nanobot
 from loguru import logger
 from nanobot.agent.hook import AgentHook
 from nanobot.agent.loop import AgentLoop
+from nanobot.channels.manager import ChannelManager
 
 _SUPPORTED_PREFIXES = ("0.1.5",)
 
@@ -46,6 +48,67 @@ def _install_monkey_patch(hooks_factory: HooksFactory) -> None:
     AgentLoop.__init__ = _patched_init  # type: ignore[assignment]
 
 
+def _install_channel_manager_patch() -> None:
+    """Generalize ChannelManager's ``session_manager`` injection.
+
+    Upstream only forwards ``session_manager`` to the built-in ``websocket``
+    channel (``nanobot/channels/manager.py`` gates on ``cls.name == "websocket"``).
+    We need the same dependency on ``desktop_mate`` for its REST surface.
+
+    Rather than duplicate 25 lines of ``_init_channels``, we wrap it: before
+    each class instantiation, inspect the constructor signature and, when it
+    declares a ``session_manager`` parameter, inject our stored reference.
+    This makes the fix generic for any future channel and trivially
+    compatible with the upstream guard (we set the kwarg before upstream's
+    conditional runs).
+    """
+    _orig_init_channels = ChannelManager._init_channels
+
+    def _patched_init_channels(self: ChannelManager) -> None:
+        from nanobot.channels.registry import discover_all
+
+        sm = getattr(self, "_session_manager", None)
+        if sm is None:
+            _orig_init_channels(self)
+            return
+
+        # Temporarily wrap each discovered channel's ``__init__`` to default-
+        # inject ``session_manager`` when the signature accepts it. Upstream's
+        # guard only fires for ``cls.name == "websocket"`` — this expands it
+        # to any channel that declares the kwarg (e.g. ``desktop_mate``).
+        # Restored after the original ``_init_channels`` returns.
+        patched: list[tuple[type, Any]] = []
+        try:
+            for cls in discover_all().values():
+                try:
+                    sig = inspect.signature(cls.__init__)
+                except (TypeError, ValueError):
+                    continue
+                if "session_manager" not in sig.parameters:
+                    continue
+                orig_cls_init = cls.__init__
+
+                def _make_wrapper(orig: Any) -> Any:
+                    def _wrapped(inst: Any, *a: Any, **kw: Any) -> None:
+                        kw.setdefault("session_manager", sm)
+                        orig(inst, *a, **kw)
+
+                    return _wrapped
+
+                cls.__init__ = _make_wrapper(orig_cls_init)  # type: ignore[method-assign]
+                patched.append((cls, orig_cls_init))
+            _orig_init_channels(self)
+        finally:
+            for cls, orig in patched:
+                cls.__init__ = orig  # type: ignore[method-assign]
+
+    ChannelManager._init_channels = _patched_init_channels  # type: ignore[assignment]
+    logger.debug(
+        "nanobot_runtime: patched ChannelManager._init_channels for "
+        "generic session_manager injection"
+    )
+
+
 def run(
     *,
     hooks_factory: HooksFactory,
@@ -58,6 +121,7 @@ def run(
     ``NANOBOT_WORKSPACE`` env vars, then to ``./nanobot.json`` / ``.``.
     """
     _install_monkey_patch(hooks_factory)
+    _install_channel_manager_patch()
 
     # Import after patch so any import-time side effects see the patched class.
     from nanobot.cli.commands import app

--- a/tests/channels/test_desktop_mate_rest.py
+++ b/tests/channels/test_desktop_mate_rest.py
@@ -1,0 +1,315 @@
+"""Tests for DesktopMateChannel's REST surface (session list / messages / delete).
+
+Routes mirror nanobot's WebSocketChannel but with a ``desktop_mate:`` prefix
+filter and the channel's static ``?token=`` auth (instead of the TTL pool).
+These unit tests exercise ``_dispatch_http`` directly with fake requests
+and a fake SessionManager — no real socket binding.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from nanobot_runtime.channels.desktop_mate import (
+    DesktopMateChannel,
+    DesktopMateConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeHeaders(dict):
+    """Case-insensitive enough for our bearer_token() helper."""
+
+
+class FakeRequest:
+    def __init__(self, path: str, headers: dict[str, str] | None = None):
+        self.path = path
+        self.headers = FakeHeaders(headers or {})
+
+
+class FakeBus:
+    async def publish_inbound(self, msg: Any) -> None:  # pragma: no cover - unused
+        pass
+
+    async def publish_outbound(self, msg: Any) -> None:  # pragma: no cover - unused
+        pass
+
+
+class FakeSessionManager:
+    def __init__(
+        self,
+        *,
+        sessions: list[dict[str, Any]] | None = None,
+        files: dict[str, dict[str, Any]] | None = None,
+        deletable: set[str] | None = None,
+    ):
+        self._sessions = sessions or []
+        self._files = files or {}
+        self._deletable = deletable or set()
+        self.deleted: list[str] = []
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        return list(self._sessions)
+
+    def read_session_file(self, key: str) -> dict[str, Any] | None:
+        return self._files.get(key)
+
+    def delete_session(self, key: str) -> bool:
+        self.deleted.append(key)
+        return key in self._deletable
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_channel(
+    *,
+    token: str = "secret",
+    session_manager: Any | None = None,
+) -> DesktopMateChannel:
+    return DesktopMateChannel(
+        config=DesktopMateConfig(token=token, host="127.0.0.1", port=0, path="/ws"),
+        bus=FakeBus(),
+        emotion_emojis=set(),
+        session_manager=session_manager,
+    )
+
+
+def _body_json(response: Any) -> dict[str, Any]:
+    return json.loads(response.body.decode("utf-8"))
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_unknown_path_returns_404():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    req = FakeRequest("/nope")
+    resp = asyncio.run(ch._dispatch_http(connection=None, request=req))
+    assert resp.status_code == 404
+
+
+def test_dispatch_ws_upgrade_falls_through_to_handshake():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    req = FakeRequest(
+        "/ws?token=secret",
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
+    )
+    resp = asyncio.run(ch._dispatch_http(connection=None, request=req))
+    assert resp is None  # None → websockets lib continues the handshake
+
+
+def test_dispatch_non_upgrade_to_ws_path_is_404():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    # Plain GET to /ws without Upgrade header should not be treated as an
+    # unauth'd handshake — just a miss.
+    req = FakeRequest("/ws")
+    resp = asyncio.run(ch._dispatch_http(connection=None, request=req))
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions (list)
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_list_filters_prefix_and_strips_path():
+    sm = FakeSessionManager(
+        sessions=[
+            {"key": "desktop_mate:abc", "created_at": "t1", "updated_at": "t2", "path": "/x/abc.jsonl"},
+            {"key": "desktop_mate:def", "created_at": "t3", "updated_at": "t4", "path": "/x/def.jsonl"},
+            {"key": "websocket:foo", "created_at": "t5", "updated_at": "t6", "path": "/x/foo.jsonl"},
+            {"key": "slack:C1:1.0", "created_at": "t7", "updated_at": "t8", "path": "/x/s.jsonl"},
+        ],
+    )
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret")))
+    assert resp.status_code == 200
+    data = _body_json(resp)
+    keys = [s["key"] for s in data["sessions"]]
+    assert keys == ["desktop_mate:abc", "desktop_mate:def"]
+    for s in data["sessions"]:
+        assert "path" not in s
+
+
+def test_sessions_list_401_when_token_missing():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions")))
+    assert resp.status_code == 401
+
+
+def test_sessions_list_401_when_token_wrong():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=bogus")))
+    assert resp.status_code == 401
+
+
+def test_sessions_list_accepts_bearer_header():
+    sm = FakeSessionManager(sessions=[])
+    ch = _make_channel(session_manager=sm)
+    req = FakeRequest("/api/sessions", headers={"Authorization": "Bearer secret"})
+    resp = asyncio.run(ch._dispatch_http(None, req))
+    assert resp.status_code == 200
+
+
+def test_sessions_list_503_when_manager_missing():
+    ch = _make_channel(session_manager=None)
+    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret")))
+    assert resp.status_code == 503
+
+
+def test_sessions_list_allows_all_when_no_token_configured():
+    sm = FakeSessionManager(sessions=[])
+    ch = DesktopMateChannel(
+        config=DesktopMateConfig(token="", host="127.0.0.1", port=0, path="/ws"),
+        bus=FakeBus(),
+        emotion_emojis=set(),
+        session_manager=sm,
+    )
+    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions")))
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions/{key}/messages (read)
+# ---------------------------------------------------------------------------
+
+
+def test_session_messages_happy_path():
+    sm = FakeSessionManager(
+        files={
+            "desktop_mate:abc": {
+                "key": "desktop_mate:abc",
+                "created_at": "t",
+                "updated_at": "t",
+                "metadata": {},
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        }
+    )
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/desktop_mate:abc/messages?token=secret")
+        )
+    )
+    assert resp.status_code == 200
+    data = _body_json(resp)
+    assert data["key"] == "desktop_mate:abc"
+    assert data["messages"][0]["content"] == "hi"
+
+
+def test_session_messages_400_invalid_key_chars():
+    sm = FakeSessionManager()
+    ch = _make_channel(session_manager=sm)
+    # Space is not in the allowed charset.
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/bad%20key/messages?token=secret")
+        )
+    )
+    assert resp.status_code == 400
+
+
+def test_session_messages_404_wrong_prefix():
+    sm = FakeSessionManager(
+        files={"websocket:foo": {"key": "websocket:foo", "messages": []}}
+    )
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/websocket:foo/messages?token=secret")
+        )
+    )
+    assert resp.status_code == 404
+
+
+def test_session_messages_404_when_not_found():
+    sm = FakeSessionManager(files={})
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None,
+            FakeRequest("/api/sessions/desktop_mate:missing/messages?token=secret"),
+        )
+    )
+    assert resp.status_code == 404
+
+
+def test_session_messages_401_no_token():
+    ch = _make_channel(session_manager=FakeSessionManager())
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/desktop_mate:x/messages")
+        )
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions/{key}/delete
+# ---------------------------------------------------------------------------
+
+
+def test_session_delete_true():
+    sm = FakeSessionManager(deletable={"desktop_mate:abc"})
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/desktop_mate:abc/delete?token=secret")
+        )
+    )
+    assert resp.status_code == 200
+    assert _body_json(resp) == {"deleted": True}
+    assert sm.deleted == ["desktop_mate:abc"]
+
+
+def test_session_delete_false_when_missing():
+    sm = FakeSessionManager(deletable=set())
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/desktop_mate:abc/delete?token=secret")
+        )
+    )
+    assert resp.status_code == 200
+    assert _body_json(resp) == {"deleted": False}
+
+
+def test_session_delete_404_wrong_prefix():
+    sm = FakeSessionManager(deletable={"websocket:foo"})
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/websocket:foo/delete?token=secret")
+        )
+    )
+    assert resp.status_code == 404
+    # Cross-channel delete must be blocked even before reaching the manager.
+    assert sm.deleted == []
+
+
+def test_session_delete_400_invalid_key():
+    sm = FakeSessionManager()
+    ch = _make_channel(session_manager=sm)
+    resp = asyncio.run(
+        ch._dispatch_http(
+            None, FakeRequest("/api/sessions/ohno%21bang/delete?token=secret")
+        )
+    )
+    assert resp.status_code == 400

--- a/tests/channels/test_gateway_sm_injection.py
+++ b/tests/channels/test_gateway_sm_injection.py
@@ -1,0 +1,71 @@
+"""Smoke test: gateway's ChannelManager patch wires session_manager into DesktopMateChannel.
+
+Nanobot's upstream ``ChannelManager._init_channels`` only forwards
+``session_manager`` to the built-in ``websocket`` channel. Our gateway
+patches the method to forward it to any channel whose ``__init__``
+declares the kwarg — including ``desktop_mate``. This test verifies the
+patch actually takes effect by constructing a ``ChannelManager`` with a
+fake session manager and confirming the channel received it.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nanobot_runtime.channels.desktop_mate import DesktopMateChannel
+from nanobot_runtime.gateway import _install_channel_manager_patch
+
+
+class _FakeBus:
+    async def publish_inbound(self, msg: Any) -> None:  # pragma: no cover
+        pass
+
+    async def publish_outbound(self, msg: Any) -> None:  # pragma: no cover
+        pass
+
+
+def test_gateway_patch_injects_session_manager_into_desktop_mate():
+    """After the patch runs, a ChannelManager built with a session_manager
+    must forward it to DesktopMateChannel at construction time.
+    """
+    # Install the patch. Idempotent under repeat calls is not asserted —
+    # in a full run the gateway installs it exactly once at startup.
+    _install_channel_manager_patch()
+
+    from nanobot.channels.manager import ChannelManager
+    from nanobot.config.schema import Config
+
+    # Build the minimum config that enables only desktop_mate. Other sections
+    # default-disabled; we don't want websocket or slack contending for ports.
+    config = Config.model_validate(
+        {
+            "agents": {
+                "defaults": {"model": "test-model"},
+            },
+            "channels": {
+                "desktop_mate": {
+                    "enabled": True,
+                    "host": "127.0.0.1",
+                    "port": 0,
+                    "path": "/ws",
+                    "token": "secret",
+                }
+            },
+        }
+    )
+
+    fake_sm = MagicMock()
+    fake_sm.list_sessions.return_value = []
+
+    mgr = ChannelManager(config, _FakeBus(), session_manager=fake_sm)
+
+    channel = mgr.channels.get("desktop_mate")
+    assert isinstance(channel, DesktopMateChannel), (
+        "desktop_mate channel did not initialise; patch may have regressed"
+    )
+    assert channel._session_manager is fake_sm, (
+        "gateway patch failed to inject session_manager into DesktopMateChannel"
+    )


### PR DESCRIPTION
## Summary
- Adds GET `/api/sessions`, `/api/sessions/{key}/messages`, and `/api/sessions/{key}/delete` to `DesktopMateChannel`, mirroring nanobot's `WebSocketChannel` surface so the Unity FE sidebar (list/history/delete) keeps working against the new backend.
- Reuses the existing static `?token=` (also accepts `Authorization: Bearer`) for auth — simpler than nanobot's TTL pool. Prefix filter keeps the surface scoped to `desktop_mate:` sessions only.
- Gateway now patches `ChannelManager._init_channels` generically: any channel that declares a `session_manager` kwarg receives it (upstream only hard-codes `cls.name == "websocket"`).
- Title-modification is intentionally omitted — nanobot has no PATCH metadata endpoint and the UX was deferred.

## Test plan
- [x] Unit: 18 cases in `tests/channels/test_desktop_mate_rest.py` — prefix filter, 401/503/404/400 paths, bearer + query-string token, cross-channel delete blocked, empty-token allow-all, URL-encoded invalid chars.
- [x] Unit: 1 case in `tests/channels/test_gateway_sm_injection.py` verifying the gateway patch actually wires `session_manager` into `DesktopMateChannel`.
- [x] Full channel suite 78/78 passes; pre-existing failures in `test_tts_hook.py` / `test_scenarios.py` are unrelated (nanobot signature drift).
- [ ] Live E2E handshake against the Unity FE (deferred to Phase 3-C FE migration when the WS client is rewritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)