### PR TITLE
docs(operations): note DesktopMateChannel mirrors session REST

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,6 +125,12 @@ curl -X POST http://127.0.0.1:<gateway-port>/api/sessions/<channel>%3A<chat_id>/
 
 세션 키 포맷: `channel:chat_id` (URL 인코딩 시 `%3A`).
 
+nanobot 내장 `websocket` 채널과 `DesktopMateChannel` 모두 동일한 3개 라우트를
+노출한다 (DesktopMate 쪽은 `src/nanobot_runtime/channels/desktop_mate_rest.py`
+에서 mirror 구현, 전체 키의 `desktop_mate:` prefix 로 자기 세션만 필터링).
+인증은 두 채널 모두 `?token=<>` 쿼리 파라미터 또는 `Authorization: Bearer <>`
+헤더를 재사용한다.
+
 ---
 
 ## 4. 확장


### PR DESCRIPTION
## Summary

- Clarifies that both the built-in \`websocket\` channel and \`DesktopMateChannel\` expose the same three session REST routes.
- Points at \`src/nanobot_runtime/channels/desktop_mate_rest.py\` for the mirror implementation (added in b983d67).
- Pins the auth contract (\`?token=\` query param **or** \`Authorization: Bearer\` header) — identical across both channels.

Pure docs, no runtime change.

## Runtime component(s) touched

- [x] Docs / setup / operations

## nanobot-ai compatibility

N/A — no upstream contact.

## Test plan

- [ ] Render \`docs/operations.md\` on GitHub, confirm the new paragraph sits under the \`세션 REST API\` subsection and reads clearly.

## Notes for reviewer

Issue hit during a doc-drift audit after b983d67 landed. The REST section was already in place (from 60da458) but didn't name \`DesktopMateChannel\` explicitly, so a reader couldn't tell whether the routes were nanobot-builtin, desktop_mate-specific, or both. Six lines added, zero removed.