### PR TITLE
feat(channels): image intake via DesktopMateChannel (refs #8)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,6 +125,19 @@ curl -X POST http://127.0.0.1:<gateway-port>/api/sessions/<channel>%3A<chat_id>/
 
 세션 키 포맷: `channel:chat_id` (URL 인코딩 시 `%3A`).
 
+### 이미지 첨부 (inbound `images`)
+
+`new_chat` / `message` 프레임에 `images: list[str]` 필드를 실어 멀티모달
+입력을 보낼 수 있다. 각 항목은 반드시 `data:<mime>;base64,<payload>`
+형식의 data URL (원시 base64 문자열 불가). 캡: 프레임당 최대 4장,
+장당 디코드 후 10MB. 허용 MIME 은 `image/png`, `image/jpeg`,
+`image/webp`, `image/gif` — SVG 는 XSS 리스크로 차단된다. 검증 실패 시
+채널은 turn 전체를 거부하고 `{"event": "image_rejected", "reason":
+"malformed" | "too_large" | "unsupported_mime"}` 프레임을 돌려준다.
+디코드된 파일은 nanobot 의 `get_media_dir("desktop_mate")` 아래에
+저장되고, 로컬 경로가 `BaseChannel._handle_message(..., media=...)` 로
+전달되어 이후 멀티모달 변환은 nanobot 측이 자동 처리한다.
+
 ---
 
 ## 4. 확장

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,10 +133,24 @@ curl -X POST http://127.0.0.1:<gateway-port>/api/sessions/<channel>%3A<chat_id>/
 장당 디코드 후 10MB. 허용 MIME 은 `image/png`, `image/jpeg`,
 `image/webp`, `image/gif` — SVG 는 XSS 리스크로 차단된다. 검증 실패 시
 채널은 turn 전체를 거부하고 `{"event": "image_rejected", "reason":
-"malformed" | "too_large" | "unsupported_mime"}` 프레임을 돌려준다.
-디코드된 파일은 nanobot 의 `get_media_dir("desktop_mate")` 아래에
-저장되고, 로컬 경로가 `BaseChannel._handle_message(..., media=...)` 로
-전달되어 이후 멀티모달 변환은 nanobot 측이 자동 처리한다.
+<reason>, "reference_id": <echo>}` 프레임을 돌려준다. `reason` 은 다음
+다섯 토큰 중 하나로 고정된다:
+
+- `malformed` — data URL 파싱 실패 / base64 복호 실패 (caller-fixable)
+- `too_large` — 디코드 후 장당 10MB 초과
+- `unsupported_mime` — allow-list 외 MIME (SVG 포함)
+- `too_many` — 한 프레임에 4장 초과 동봉
+- `io_error` — 서버 측 저장 실패 (디스크 풀, 권한). 사용자 입력 문제가
+  아니므로 FE 는 일시적 오류로 취급해 재시도를 권장한다.
+
+`reference_id` 는 인바운드 envelope 의 필드를 그대로 에코하므로, FE 는
+`new_chat` 거부 (아직 `chat_id` 미할당) 경우에도 어떤 in-flight send 에
+대한 거부인지 매칭할 수 있다. 디코드된 파일은 nanobot 의
+`get_media_dir("desktop_mate")` 아래에 저장되고, 로컬 경로가
+`BaseChannel._handle_message(..., media=...)` 로 전달되어 이후 멀티모달
+변환은 nanobot 측이 자동 처리한다. 다운스트림 전달 도중 예외가 나면
+채널이 디코드된 미디어를 unlink 하므로 rejected turn 의 파일이 디스크에
+잔류하지 않는다.
 
 ---
 

--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -24,6 +24,7 @@ are explicitly out of scope and can layer on later.
 from __future__ import annotations
 
 import asyncio
+import binascii
 import re
 import time
 import uuid
@@ -45,12 +46,14 @@ from nanobot.utils.media_decode import FileSizeExceeded, save_base64_data_url
 from nanobot_runtime.channels.desktop_mate_protocol import (
     DeltaFrame,
     ImageRejectedFrame,
+    ImageRejectReason,
     MessageFrame,
     NewChatFrame,
     ReadyFrame,
     StreamEndFrame,
     StreamStartFrame,
     TTSChunkFrame,
+    _MAX_IMAGES_PER_MESSAGE,
     parse_inbound,
 )
 from nanobot_runtime.channels.desktop_mate_rest import (
@@ -322,21 +325,48 @@ class DesktopMateChannel(BaseChannel):
         return resolved
 
     def _decode_inbound_images(
-        self, images: list[str] | None
-    ) -> tuple[list[str], str | None]:
+        self,
+        images: list[str] | None,
+        *,
+        sender_id: str,
+    ) -> tuple[list[str], ImageRejectReason | None]:
         """Decode a frame's ``images`` entries to disk.
 
         Returns ``(paths, None)`` on success or ``([], reason)`` on the
-        first failure (whole turn rejected — no partial ingress). Reason
-        tokens are stable: ``"malformed"``, ``"too_large"``,
-        ``"unsupported_mime"``.
+        first failure (whole turn rejected — no partial ingress). Every
+        rejection is logged with ``sender_id`` + mime + size so MIME
+        violations (a potential XSS / XXE surface) and server-side IO
+        failures are observable to ops. ``ImageRejectReason`` is the
+        closed set documented on :class:`ImageRejectedFrame`.
         """
         if not images:
             return [], None
+
+        if len(images) > _MAX_IMAGES_PER_MESSAGE:
+            logger.warning(
+                "desktop_mate: rejecting inbound images from {}: "
+                "count={} exceeds cap={} (reason=too_many)",
+                sender_id, len(images), _MAX_IMAGES_PER_MESSAGE,
+            )
+            return [], "too_many"
+
         media_dir = self._resolve_media_dir()
         saved_paths: list[str] = []
 
-        def _abort(reason: str) -> tuple[list[str], str]:
+        def _abort(
+            reason: ImageRejectReason,
+            *,
+            mime: str | None = None,
+            size_hint: int | None = None,
+        ) -> tuple[list[str], ImageRejectReason]:
+            # io_error is a server-side failure (disk full, permission,
+            # media dir gone); everything else is caller-fixable.
+            level = "error" if reason == "io_error" else "warning"
+            getattr(logger, level)(
+                "desktop_mate: rejecting inbound image from {}: "
+                "reason={} mime={} size_hint={}",
+                sender_id, reason, mime, size_hint,
+            )
             # Any image already written before a later entry fails must be
             # unlinked — partial state on disk confuses downstream cleanup.
             for p in saved_paths:
@@ -356,20 +386,29 @@ class DesktopMateChannel(BaseChannel):
             if mime is None:
                 return _abort("malformed")
             if mime not in _IMAGE_MIME_ALLOWED:
-                return _abort("unsupported_mime")
+                return _abort("unsupported_mime", mime=mime)
             try:
                 saved = save_base64_data_url(
                     entry, media_dir, max_bytes=self._max_image_bytes,
                 )
             except FileSizeExceeded:
-                return _abort("too_large")
-            except Exception:
-                logger.opt(exception=True).warning(
-                    "desktop_mate: image decode failed"
+                return _abort("too_large", mime=mime, size_hint=len(entry))
+            except (binascii.Error, ValueError) as exc:
+                # Malformed base64 / bad data URL payload. Caller-fixable.
+                logger.debug(
+                    "desktop_mate: decode failed (caller-fixable): {}", exc
                 )
-                return _abort("malformed")
+                return _abort("malformed", mime=mime, size_hint=len(entry))
+            except OSError as exc:
+                # Disk write failure (full FS, permission, missing dir).
+                # Server-side problem — surface as io_error so FE can
+                # retry rather than blame the user's image.
+                logger.opt(exception=True).error(
+                    "desktop_mate: image persist failed: {}", exc
+                )
+                return _abort("io_error", mime=mime, size_hint=len(entry))
             if saved is None:
-                return _abort("malformed")
+                return _abort("malformed", mime=mime, size_hint=len(entry))
             saved_paths.append(saved)
         return saved_paths, None
 
@@ -753,15 +792,19 @@ class DesktopMateChannel(BaseChannel):
                 chat_id = envelope.chat_id
 
             media_paths, reject_reason = self._decode_inbound_images(
-                envelope.images
+                envelope.images, sender_id=sender_id,
             )
             if reject_reason is not None:
+                # new_chat rejections carry no chat_id — the session was
+                # never created. FE correlates via ``reference_id`` instead
+                # when it needs to match the rejection to its pending send.
                 await self._send_frame(
                     connection,
                     ImageRejectedFrame(
                         chat_id=chat_id if isinstance(envelope, MessageFrame)
                         else None,
                         reason=reject_reason,
+                        reference_id=envelope.reference_id,
                     ),
                 )
                 continue
@@ -770,13 +813,33 @@ class DesktopMateChannel(BaseChannel):
             # Record per-chat TTS policy from the inbound flag. Connection
             # URL override (``?tts=0``) still wins in ``_tts_enabled_for_chat``.
             self._tts_enabled_per_chat[chat_id] = bool(envelope.tts_enabled)
-            await self._handle_message(
-                sender_id=sender_id,
-                chat_id=chat_id,
-                content=envelope.content,
-                media=media_paths or None,
-                metadata=base_metadata,
-            )
+            # Hand-off to the bus. If this raises (or the allow_from check
+            # inside silently rejects), decoded image files would leak on
+            # disk; unlink them on any non-happy exit. We don't propagate
+            # the exception — the connection should keep serving further
+            # frames from the same client.
+            try:
+                await self._handle_message(
+                    sender_id=sender_id,
+                    chat_id=chat_id,
+                    content=envelope.content,
+                    media=media_paths or None,
+                    metadata=base_metadata,
+                )
+            except Exception as exc:
+                logger.opt(exception=True).error(
+                    "desktop_mate: handle_message failed (chat_id={}): {}",
+                    chat_id, exc,
+                )
+                for p in media_paths:
+                    try:
+                        Path(p).unlink(missing_ok=True)
+                    except OSError as unlink_exc:
+                        logger.warning(
+                            "desktop_mate: leaked media {} "
+                            "(unlink after handle_message failure): {}",
+                            p, unlink_exc,
+                        )
 
     # -- Server lifecycle --------------------------------------------------
 

--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -94,9 +94,11 @@ class DesktopMateConfig:
     # WS protocol-level keepalive (seconds). Set to None to disable.
     ping_interval_s: float | None = 20.0
     ping_timeout_s: float | None = 20.0
-    # Max inbound frame size in bytes. 6MB accommodates the DMP image cap
-    # (~4.5MB binary ≈ ~6MB base64).
-    max_message_bytes: int = 6 * 1024 * 1024
+    # Max inbound frame size in bytes.  Must be large enough to fit the
+    # worst-case image payload: _MAX_IMAGES_PER_MESSAGE (4) × _MAX_IMAGE_BYTES
+    # (10 MB) base64-encoded (×4/3) ≈ 53 MB.  60 MB gives headroom for JSON
+    # framing and future cap adjustments.
+    max_message_bytes: int = 60 * 1024 * 1024
     # Path to the YAML file whose ``emotion_motion_map`` keys enumerate the
     # emojis the channel should strip from outbound ``delta`` text. Same file
     # the TTSHook loads for keyframe mapping — kept in sync naturally.

--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -28,6 +28,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -39,9 +40,11 @@ from websockets.http11 import Response
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
+from nanobot.utils.media_decode import FileSizeExceeded, save_base64_data_url
 
 from nanobot_runtime.channels.desktop_mate_protocol import (
     DeltaFrame,
+    ImageRejectedFrame,
     MessageFrame,
     NewChatFrame,
     ReadyFrame,
@@ -108,6 +111,28 @@ _CAMEL_TO_SNAKE: dict[str, str] = {
     "maxMessageBytes": "max_message_bytes",
     "emotionMapPath": "emotion_map_path",
 }
+
+
+# Per-image ingress caps (issue #8). Matches upstream nanobot's built-in
+# WS channel intent: 10 MB per image is the user-facing ceiling, SVG is
+# excluded to avoid embedded-script XSS surface.
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+_IMAGE_MIME_ALLOWED: frozenset[str] = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+})
+_DATA_URL_MIME_RE = re.compile(r"^data:([^;]+);base64,", re.DOTALL)
+
+
+def _extract_data_url_mime(url: str) -> str | None:
+    if not isinstance(url, str):
+        return None
+    m = _DATA_URL_MIME_RE.match(url)
+    if not m:
+        return None
+    return m.group(1).strip().lower() or None
 
 
 def _load_emotion_emojis_from_yaml(path: str) -> set[str]:
@@ -253,6 +278,13 @@ class DesktopMateChannel(BaseChannel):
         self._stop_event: asyncio.Event | None = None
         self._server_task: asyncio.Task[None] | None = None
         self._server: Any | None = None
+        # Per-image byte cap — exposed as an instance attr so tests can
+        # dial it down without base64-encoding 10 MB of padding per case.
+        self._max_image_bytes: int = _MAX_IMAGE_BYTES
+        # Media directory for decoded inbound images. Resolved lazily via
+        # :meth:`_resolve_media_dir` so tests can override by assigning
+        # ``channel._media_dir`` before triggering the inbound loop.
+        self._media_dir: Path | None = None
 
     # -- Subscription bookkeeping ------------------------------------------
 
@@ -271,6 +303,75 @@ class DesktopMateChannel(BaseChannel):
                 self._streams.pop(sid, None)
                 if self._current_stream_id == sid:
                     self._current_stream_id = None
+
+    # -- Image intake ------------------------------------------------------
+
+    def _resolve_media_dir(self) -> Path:
+        """Return the directory inbound images are persisted to.
+
+        Uses nanobot's ``get_media_dir("desktop_mate")`` so the FS layout
+        matches the built-in WS channel. Lazy-evaluated so construction
+        order (channel-first vs config-first) doesn't matter.
+        """
+        if self._media_dir is not None:
+            return self._media_dir
+        from nanobot.config.paths import get_media_dir
+
+        resolved = get_media_dir("desktop_mate")
+        self._media_dir = resolved
+        return resolved
+
+    def _decode_inbound_images(
+        self, images: list[str] | None
+    ) -> tuple[list[str], str | None]:
+        """Decode a frame's ``images`` entries to disk.
+
+        Returns ``(paths, None)`` on success or ``([], reason)`` on the
+        first failure (whole turn rejected — no partial ingress). Reason
+        tokens are stable: ``"malformed"``, ``"too_large"``,
+        ``"unsupported_mime"``.
+        """
+        if not images:
+            return [], None
+        media_dir = self._resolve_media_dir()
+        saved_paths: list[str] = []
+
+        def _abort(reason: str) -> tuple[list[str], str]:
+            # Any image already written before a later entry fails must be
+            # unlinked — partial state on disk confuses downstream cleanup.
+            for p in saved_paths:
+                try:
+                    Path(p).unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning(
+                        "desktop_mate: failed to unlink partial media {}: {}",
+                        p, exc,
+                    )
+            return [], reason
+
+        for entry in images:
+            if not isinstance(entry, str) or not entry:
+                return _abort("malformed")
+            mime = _extract_data_url_mime(entry)
+            if mime is None:
+                return _abort("malformed")
+            if mime not in _IMAGE_MIME_ALLOWED:
+                return _abort("unsupported_mime")
+            try:
+                saved = save_base64_data_url(
+                    entry, media_dir, max_bytes=self._max_image_bytes,
+                )
+            except FileSizeExceeded:
+                return _abort("too_large")
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "desktop_mate: image decode failed"
+                )
+                return _abort("malformed")
+            if saved is None:
+                return _abort("malformed")
+            saved_paths.append(saved)
+        return saved_paths, None
 
     # -- TTS policy --------------------------------------------------------
 
@@ -651,6 +752,20 @@ class DesktopMateChannel(BaseChannel):
                 assert isinstance(envelope, MessageFrame)
                 chat_id = envelope.chat_id
 
+            media_paths, reject_reason = self._decode_inbound_images(
+                envelope.images
+            )
+            if reject_reason is not None:
+                await self._send_frame(
+                    connection,
+                    ImageRejectedFrame(
+                        chat_id=chat_id if isinstance(envelope, MessageFrame)
+                        else None,
+                        reason=reject_reason,
+                    ),
+                )
+                continue
+
             self._attach(chat_id, connection)
             # Record per-chat TTS policy from the inbound flag. Connection
             # URL override (``?tts=0``) still wins in ``_tts_enabled_for_chat``.
@@ -659,6 +774,7 @@ class DesktopMateChannel(BaseChannel):
                 sender_id=sender_id,
                 chat_id=chat_id,
                 content=envelope.content,
+                media=media_paths or None,
                 metadata=base_metadata,
             )
 

--- a/src/nanobot_runtime/channels/desktop_mate_protocol.py
+++ b/src/nanobot_runtime/channels/desktop_mate_protocol.py
@@ -5,7 +5,8 @@ schema in one place (rather than scattered dict literals inside the
 channel) makes the contract auditable and prevents silent drift:
 
 * Outbound (server→FE): :class:`StreamStartFrame` / :class:`DeltaFrame`
-  / :class:`StreamEndFrame` / :class:`TTSChunkFrame`
+  / :class:`StreamEndFrame` / :class:`TTSChunkFrame` /
+  :class:`ImageRejectedFrame`
 * Inbound (FE→server): :class:`NewChatFrame` / :class:`MessageFrame`
   as a discriminated union — parse with :func:`parse_inbound`.
 
@@ -14,6 +15,12 @@ so optional fields such as ``proactive`` or ``stream_id`` are omitted
 when unset. ``TTSChunkFrame`` intentionally keeps ``audio_base64`` / ``emotion``
 serialised as explicit ``null`` because the frontend treats ``null`` as
 "TTS unavailable, play silence" — dropping the key would change semantics.
+
+Image intake (issue #8): inbound frames may carry an ``images`` field
+(a list of ``data:<mime>;base64,<payload>`` URLs, max
+:data:`_MAX_IMAGES_PER_MESSAGE` entries). Per-image byte/MIME validation
+happens at the channel layer, which surfaces :class:`ImageRejectedFrame`
+to the client on failure.
 """
 from __future__ import annotations
 
@@ -24,8 +31,14 @@ from pydantic import (
     ConfigDict,
     Field,
     TypeAdapter,
-    field_validator,
+    model_validator,
 )
+
+
+# Per-frame image cap. Mirrors upstream nanobot's built-in WS channel
+# (``nanobot.channels.websocket._MAX_IMAGES_PER_MESSAGE``) — keeping the
+# cap in lock-step avoids asymmetric surprises across ingress paths.
+_MAX_IMAGES_PER_MESSAGE = 4
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +92,22 @@ class StreamEndFrame(_OutboundBase):
     content: str
 
 
+class ImageRejectedFrame(BaseModel):
+    """Sent when the channel refuses to accept a turn's ``images`` payload.
+
+    Carries a short, stable ``reason`` token (``"malformed"``,
+    ``"too_large"``, ``"unsupported_mime"``, ``"too_many"``) so the FE can
+    render a localized message without parsing free-form prose. The whole
+    turn is rejected — the agent loop is never entered.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event: Literal["image_rejected"] = "image_rejected"
+    chat_id: str | None = None
+    reason: str
+
+
 class TTSChunkFrame(_OutboundBase):
     event: Literal["tts_chunk"] = "tts_chunk"
     sequence: int
@@ -117,13 +146,25 @@ class _InboundBase(BaseModel):
     content: str
     tts_enabled: bool = True
     reference_id: str | None = None
+    # Inbound image attachments as ``data:<mime>;base64,<payload>`` URLs.
+    # Per-item byte/MIME validation happens at the channel layer — see
+    # ``DesktopMateChannel._decode_inbound_images``. Only the per-frame
+    # count cap is enforced here so malformed frames fail fast.
+    images: list[str] | None = Field(
+        default=None,
+        max_length=_MAX_IMAGES_PER_MESSAGE,
+    )
 
-    @field_validator("content")
-    @classmethod
-    def _content_must_be_non_blank(cls, value: str) -> str:
-        if not value or not value.strip():
+    @model_validator(mode="after")
+    def _content_or_images_required(self) -> "_InboundBase":
+        # Image-only turns are permitted (the LLM can caption them), so a
+        # blank ``content`` is only rejected when there are no images to
+        # carry the turn. Matches upstream websocket.py:1043.
+        has_text = bool(self.content and self.content.strip())
+        has_images = bool(self.images)
+        if not has_text and not has_images:
             raise ValueError("content must be non-empty")
-        return value
+        return self
 
 
 class NewChatFrame(_InboundBase):

--- a/src/nanobot_runtime/channels/desktop_mate_protocol.py
+++ b/src/nanobot_runtime/channels/desktop_mate_protocol.py
@@ -17,10 +17,12 @@ serialised as explicit ``null`` because the frontend treats ``null`` as
 "TTS unavailable, play silence" — dropping the key would change semantics.
 
 Image intake (issue #8): inbound frames may carry an ``images`` field
-(a list of ``data:<mime>;base64,<payload>`` URLs, max
-:data:`_MAX_IMAGES_PER_MESSAGE` entries). Per-image byte/MIME validation
-happens at the channel layer, which surfaces :class:`ImageRejectedFrame`
-to the client on failure.
+(a list of ``data:<mime>;base64,<payload>`` URLs). All validation — count,
+MIME, size, base64 well-formedness, disk-write success — happens at the
+channel layer so every failure mode surfaces to the client as an
+:class:`ImageRejectedFrame` with a stable reason token (count caps in
+particular must not fail at the Pydantic boundary, because a schema
+ValidationError would be silently dropped by the inbound loop).
 """
 from __future__ import annotations
 
@@ -92,20 +94,42 @@ class StreamEndFrame(_OutboundBase):
     content: str
 
 
+ImageRejectReason = Literal[
+    "malformed",
+    "too_large",
+    "unsupported_mime",
+    "too_many",
+    "io_error",
+]
+
+
 class ImageRejectedFrame(BaseModel):
     """Sent when the channel refuses to accept a turn's ``images`` payload.
 
-    Carries a short, stable ``reason`` token (``"malformed"``,
-    ``"too_large"``, ``"unsupported_mime"``, ``"too_many"``) so the FE can
-    render a localized message without parsing free-form prose. The whole
-    turn is rejected — the agent loop is never entered.
+    The ``reason`` field is a closed set so the FE can branch on it without
+    parsing free-form prose:
+
+    * ``"malformed"`` — the data URL couldn't be parsed / decoded;
+    * ``"too_large"`` — decoded payload exceeded the per-image byte cap;
+    * ``"unsupported_mime"`` — MIME not in the channel's allow-list;
+    * ``"too_many"`` — more than :data:`_MAX_IMAGES_PER_MESSAGE` entries
+      on a single frame;
+    * ``"io_error"`` — server-side failure persisting the decoded image
+      (disk full, permission error, etc.). Unlike the other reasons this
+      is not the caller's fault; the FE should surface it as a retryable
+      transient error, not an input-validation message.
+
+    ``reference_id`` echoes the inbound envelope's field (when present) so
+    the FE can correlate the rejection with a specific in-flight send even
+    when ``chat_id`` is absent (new_chat rejections have no chat yet).
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     event: Literal["image_rejected"] = "image_rejected"
     chat_id: str | None = None
-    reason: str
+    reason: ImageRejectReason
+    reference_id: str | None = None
 
 
 class TTSChunkFrame(_OutboundBase):
@@ -147,13 +171,12 @@ class _InboundBase(BaseModel):
     tts_enabled: bool = True
     reference_id: str | None = None
     # Inbound image attachments as ``data:<mime>;base64,<payload>`` URLs.
-    # Per-item byte/MIME validation happens at the channel layer — see
-    # ``DesktopMateChannel._decode_inbound_images``. Only the per-frame
-    # count cap is enforced here so malformed frames fail fast.
-    images: list[str] | None = Field(
-        default=None,
-        max_length=_MAX_IMAGES_PER_MESSAGE,
-    )
+    # All validation (count, MIME, size, decode) happens at the channel
+    # layer — see ``DesktopMateChannel._decode_inbound_images``. The count
+    # cap is intentionally NOT enforced here: a Pydantic ValidationError
+    # would be caught by the inbound loop's generic handler and silently
+    # dropped, so the FE would never learn why its message vanished.
+    images: list[str] | None = None
 
     @model_validator(mode="after")
     def _content_or_images_required(self) -> "_InboundBase":

--- a/tests/channels/test_desktop_mate_images.py
+++ b/tests/channels/test_desktop_mate_images.py
@@ -144,15 +144,23 @@ def test_inbound_images_defaults_to_none() -> None:
     assert env.images is None
 
 
-def test_inbound_images_rejects_too_many() -> None:
+def test_inbound_images_schema_does_not_cap_count() -> None:
+    """Count enforcement lives at the channel layer, not Pydantic.
+
+    A Pydantic ``max_length`` would raise ``ValidationError`` at parse
+    time and be silently dropped by the inbound loop — the FE would never
+    learn the turn was rejected. Regression: make sure nobody reintroduces
+    a schema-level cap.
+    """
     raw = json.dumps({
         "type": "message",
         "chat_id": "c-1",
         "content": "hi",
         "images": [TINY_PNG_DATA_URL] * 5,
     })
-    with pytest.raises(ValidationError):
-        parse_inbound(raw)
+    env = parse_inbound(raw)
+    assert isinstance(env, MessageFrame)
+    assert env.images is not None and len(env.images) == 5
 
 
 def test_inbound_images_rejects_wrong_item_type() -> None:
@@ -328,3 +336,177 @@ async def test_unsupported_mime_rejected(tmp_path: Path) -> None:
     frames = _decode_frames(conn)
     assert frames[-1]["event"] == "image_rejected"
     assert frames[-1]["reason"] == "unsupported_mime"
+
+
+async def test_too_many_images_emits_rejection_frame(tmp_path: Path) -> None:
+    """5 images ⇒ ``too_many`` rejection frame, not silent drop.
+
+    Guards against the dead-code regression where a Pydantic ``max_length``
+    would raise ``ValidationError`` pre-channel and be swallowed by the
+    inbound loop's generic handler — leaving FE without any rejection.
+    """
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL] * 5,
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames[-1]["event"] == "image_rejected"
+    assert frames[-1]["reason"] == "too_many"
+    # Nothing should have been written to disk yet — the count check
+    # short-circuits before any decode work begins.
+    assert list((tmp_path / "media").iterdir()) == []
+
+
+async def test_partial_ingress_cleanup_on_later_failure(tmp_path: Path) -> None:
+    """First image succeeds, second exceeds cap ⇒ first file must be unlinked.
+
+    The channel promises whole-turn rejection with no partial state on
+    disk. Without explicit coverage a future refactor could silently drop
+    the ``_abort`` unlink loop and accumulate leaked bytes per rejection.
+    """
+    channel, bus = _make_channel(tmp_path)
+    channel._max_image_bytes = 32
+    oversized_payload = base64.b64encode(b"X" * 256).decode("ascii")
+    oversized_url = f"data:image/png;base64,{oversized_payload}"
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL, oversized_url],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames[-1]["reason"] == "too_large"
+    # Crucial: the earlier-decoded tiny PNG must not be left behind.
+    media_dir = tmp_path / "media"
+    assert list(media_dir.iterdir()) == []
+
+
+async def test_io_error_during_persist_surfaces_as_io_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disk-write failures are ``io_error``, not ``malformed``.
+
+    Masking OSError as malformed misleads operators into debugging user
+    input when the actual fault is server-side (disk full, permission).
+    """
+    channel, bus = _make_channel(tmp_path)
+
+    def _raise_oserror(*args: Any, **kwargs: Any) -> str:
+        raise OSError("disk write failed (simulated)")
+
+    monkeypatch.setattr(
+        "nanobot_runtime.channels.desktop_mate.save_base64_data_url",
+        _raise_oserror,
+    )
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames[-1]["event"] == "image_rejected"
+    assert frames[-1]["reason"] == "io_error"
+
+
+async def test_reference_id_echoed_on_rejection(tmp_path: Path) -> None:
+    """FE needs ``reference_id`` to correlate rejections with pending sends.
+
+    Especially important for ``new_chat`` where ``chat_id`` is ``None`` on
+    rejection (session was never created) — without reference_id the FE
+    has no way to match the rejection to an in-flight request.
+    """
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "new_chat",
+            "content": "see",
+            "reference_id": "req-42",
+            "images": [_TINY_PNG_B64],  # missing data: prefix => malformed
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    frames = _decode_frames(conn)
+    rejection = frames[-1]
+    assert rejection["event"] == "image_rejected"
+    assert rejection["reason"] == "malformed"
+    assert rejection["reference_id"] == "req-42"
+    assert rejection.get("chat_id") is None
+
+
+async def test_exact_boundary_four_images_accepted(tmp_path: Path) -> None:
+    """Inclusive count cap: exactly ``_MAX_IMAGES_PER_MESSAGE`` must pass.
+
+    Guards against an off-by-one flip (``>=`` vs ``>``) that the
+    over-cap test alone would not catch.
+    """
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL] * 4,
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    assert len(bus.inbound[0].media) == 4
+    frames = _decode_frames(conn)
+    assert not any(f.get("event") == "image_rejected" for f in frames)
+
+
+async def test_decoded_media_unlinked_when_handle_message_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Downstream failure must not strand decoded images on disk.
+
+    ``BaseChannel._handle_message`` can raise (bus failure) or silently
+    drop (``is_allowed`` check returns False). Either way, files decoded
+    before the hand-off must be cleaned up so repeated failures don't
+    accumulate per-turn garbage.
+    """
+    channel, bus = _make_channel(tmp_path)
+
+    async def _raising_handle_message(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("bus publish failed (simulated)")
+
+    monkeypatch.setattr(channel, "_handle_message", _raising_handle_message)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    assert list((tmp_path / "media").iterdir()) == []

--- a/tests/channels/test_desktop_mate_images.py
+++ b/tests/channels/test_desktop_mate_images.py
@@ -1,0 +1,330 @@
+"""Tests for image intake on DesktopMateChannel.
+
+Covers the FE→server path added in #8: inbound ``new_chat`` / ``message``
+frames carry an optional ``images: list[str]`` field, where each entry is
+a ``data:<mime>;base64,<payload>`` URL. On success the channel decodes
+each entry to disk and forwards the resulting local paths through
+``BaseChannel._handle_message(..., media=...)``. On any failure the
+channel rejects the whole turn with an ``image_rejected`` error frame
+and does **not** publish to the bus.
+
+Uses the same ``FakeConnection`` + ``FakeBus`` shape as
+``test_desktop_mate.py`` to keep the fixtures comparable.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nanobot.bus.events import InboundMessage, OutboundMessage
+from nanobot_runtime.channels.desktop_mate import (
+    DesktopMateChannel,
+    DesktopMateConfig,
+)
+from nanobot_runtime.channels.desktop_mate_protocol import (
+    InboundEnvelope,
+    MessageFrame,
+    NewChatFrame,
+    parse_inbound,
+)
+from pydantic import ValidationError
+
+
+# 1x1 transparent PNG — smallest legal image payload, reused across tests.
+_TINY_PNG_BYTES = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO"
+    b"+ip1sAAAAASUVORK5CYII="
+)
+_TINY_PNG_B64 = base64.b64encode(_TINY_PNG_BYTES).decode("ascii")
+TINY_PNG_DATA_URL = f"data:image/png;base64,{_TINY_PNG_B64}"
+TINY_JPG_DATA_URL = (
+    "data:image/jpeg;base64,"
+    + base64.b64encode(b"\xff\xd8\xff\xd9").decode("ascii")
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes (mirror test_desktop_mate.py so fixtures read consistently)
+# ---------------------------------------------------------------------------
+
+
+class FakeConnection:
+    def __init__(
+        self,
+        inbox: list[str] | None = None,
+        remote: tuple[str, int] = ("127.0.0.1", 12345),
+    ) -> None:
+        self.sent: list[str] = []
+        self.inbox: list[str] = list(inbox or [])
+        self.remote_address = remote
+        self.closed = False
+
+    async def send(self, raw: str) -> None:
+        if self.closed:
+            raise RuntimeError("connection closed")
+        self.sent.append(raw)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        async def _gen():
+            for item in list(self.inbox):
+                yield item
+        return _gen()
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self.inbound: list[InboundMessage] = []
+        self.outbound: list[OutboundMessage] = []
+
+    async def publish_inbound(self, msg: InboundMessage) -> None:
+        self.inbound.append(msg)
+
+    async def publish_outbound(self, msg: OutboundMessage) -> None:
+        self.outbound.append(msg)
+
+
+def _make_channel(tmp_path: Path) -> tuple[DesktopMateChannel, FakeBus]:
+    bus = FakeBus()
+    cfg = DesktopMateConfig(
+        token="",
+        allow_from=["*"],
+        host="127.0.0.1",
+        port=0,
+    )
+    channel = DesktopMateChannel(config=cfg, bus=bus)
+    # Re-point media dir so tests don't dirty the user's ~/.nanobot/.
+    channel._media_dir = tmp_path / "media"
+    channel._media_dir.mkdir(parents=True, exist_ok=True)
+    return channel, bus
+
+
+def _decode_frames(conn: FakeConnection) -> list[dict[str, Any]]:
+    return [json.loads(raw) for raw in conn.sent]
+
+
+# ---------------------------------------------------------------------------
+# Protocol layer: images field on the inbound frames
+# ---------------------------------------------------------------------------
+
+
+def test_inbound_message_accepts_images_field() -> None:
+    raw = json.dumps({
+        "type": "message",
+        "chat_id": "chat-1",
+        "content": "see",
+        "images": [TINY_PNG_DATA_URL],
+    })
+    env = parse_inbound(raw)
+    assert isinstance(env, MessageFrame)
+    assert env.images == [TINY_PNG_DATA_URL]
+
+
+def test_inbound_new_chat_accepts_images_field() -> None:
+    raw = json.dumps({
+        "type": "new_chat",
+        "content": "see",
+        "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
+    })
+    env = parse_inbound(raw)
+    assert isinstance(env, NewChatFrame)
+    assert env.images == [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL]
+
+
+def test_inbound_images_defaults_to_none() -> None:
+    env = InboundEnvelope.validate_python(
+        {"type": "message", "chat_id": "c-1", "content": "hi"}
+    )
+    assert env.images is None
+
+
+def test_inbound_images_rejects_too_many() -> None:
+    raw = json.dumps({
+        "type": "message",
+        "chat_id": "c-1",
+        "content": "hi",
+        "images": [TINY_PNG_DATA_URL] * 5,
+    })
+    with pytest.raises(ValidationError):
+        parse_inbound(raw)
+
+
+def test_inbound_images_rejects_wrong_item_type() -> None:
+    raw = json.dumps({
+        "type": "message",
+        "chat_id": "c-1",
+        "content": "hi",
+        "images": [{"url": TINY_PNG_DATA_URL}],
+    })
+    with pytest.raises(ValidationError):
+        parse_inbound(raw)
+
+
+# ---------------------------------------------------------------------------
+# Channel wiring: happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_single_valid_image_is_persisted_and_forwarded(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "new_chat",
+            "content": "describe",
+            "images": [TINY_PNG_DATA_URL],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    inbound = bus.inbound[0]
+    assert inbound.content == "describe"
+    assert len(inbound.media) == 1
+    path = Path(inbound.media[0])
+    assert path.is_file()
+    assert path.read_bytes() == _TINY_PNG_BYTES
+
+
+async def test_multiple_valid_images_preserve_order(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    media = bus.inbound[0].media
+    assert len(media) == 2
+    # Order must match the inbound list so downstream can reason about
+    # which image corresponds to which mention in the text.
+    assert Path(media[0]).suffix == ".png"
+    assert Path(media[1]).suffix in (".jpe", ".jpeg", ".jpg")
+
+
+async def test_image_only_turn_accepted(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    # content is blank-ish — allowed so long as at least one image rides along.
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": " ",  # whitespace-only
+            "images": [TINY_PNG_DATA_URL],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    assert len(bus.inbound[0].media) == 1
+
+
+async def test_images_absent_is_no_op(tmp_path: Path) -> None:
+    """Regression: omitting ``images`` keeps the legacy text-only path."""
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({"type": "new_chat", "content": "hi"}),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    assert bus.inbound[0].media == []
+    # No image_rejected frame emitted — just silent-happy path.
+    events = [f.get("event") for f in _decode_frames(conn)]
+    assert "image_rejected" not in events
+
+
+async def test_images_null_is_no_op(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({"type": "new_chat", "content": "hi", "images": None}),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert len(bus.inbound) == 1
+    assert bus.inbound[0].media == []
+
+
+# ---------------------------------------------------------------------------
+# Channel wiring: rejection paths
+# ---------------------------------------------------------------------------
+
+
+async def test_malformed_data_url_rejected(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            # Missing the ``data:<mime>;base64,`` prefix — raw base64 only.
+            "images": [_TINY_PNG_B64],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames, "channel must emit an image_rejected frame"
+    assert frames[-1]["event"] == "image_rejected"
+    assert frames[-1]["reason"] == "malformed"
+
+
+async def test_oversized_image_rejected(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    # Force the per-image cap very low so we don't actually allocate ~10MB
+    # just to test the guard.
+    channel._max_image_bytes = 32
+    big_payload = base64.b64encode(b"X" * 256).decode("ascii")
+    big_url = f"data:image/png;base64,{big_payload}"
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [big_url],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames[-1]["event"] == "image_rejected"
+    assert frames[-1]["reason"] == "too_large"
+
+
+async def test_unsupported_mime_rejected(tmp_path: Path) -> None:
+    channel, bus = _make_channel(tmp_path)
+    svg_url = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
+    conn = FakeConnection(inbox=[
+        json.dumps({
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [svg_url],
+        }),
+    ])
+
+    await channel._connection_loop(conn, sender_id="user-1")
+
+    assert bus.inbound == []
+    frames = _decode_frames(conn)
+    assert frames[-1]["event"] == "image_rejected"
+    assert frames[-1]["reason"] == "unsupported_mime"

--- a/tests/channels/test_desktop_mate_protocol.py
+++ b/tests/channels/test_desktop_mate_protocol.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from nanobot_runtime.channels.desktop_mate_protocol import (
     DeltaFrame,
+    ImageRejectedFrame,
     InboundEnvelope,
     MessageFrame,
     NewChatFrame,
@@ -247,6 +248,22 @@ def test_parse_inbound_rejects_empty_content():
 def test_parse_inbound_bad_json_raises():
     with pytest.raises((ValidationError, ValueError)):
         parse_inbound("not json{{")
+
+
+def test_image_rejected_frame_serialises_minimal():
+    frame = ImageRejectedFrame(reason="too_large")
+    payload = json.loads(frame.model_dump_json(exclude_none=True))
+    assert payload == {"event": "image_rejected", "reason": "too_large"}
+
+
+def test_image_rejected_frame_with_chat_id():
+    frame = ImageRejectedFrame(chat_id="chat-A", reason="malformed")
+    payload = json.loads(frame.model_dump_json(exclude_none=True))
+    assert payload == {
+        "event": "image_rejected",
+        "chat_id": "chat-A",
+        "reason": "malformed",
+    }
 
 
 def test_inbound_envelope_is_tagged_union():

--- a/tests/e2e/test_live_scenarios.py
+++ b/tests/e2e/test_live_scenarios.py
@@ -338,3 +338,44 @@ async def test_h_inbound_tts_enabled_false(gateway, live_client) -> None:
         f"IrodoriClient.synthesize() was called with tts_enabled=false "
         f"(baseline={baseline}, after={after})"
     )
+
+
+# ---------------------------------------------------------------------------
+# Scenario I — image intake (issue #8)
+# ---------------------------------------------------------------------------
+
+
+# 1x1 transparent PNG, inline so the suite has no fixture file dependency.
+_TINY_PNG_DATA_URL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO"
+    "+ip1sAAAAASUVORK5CYII="
+)
+
+
+async def test_i_inbound_image_reaches_multimodal_pipeline(gateway, live_client) -> None:
+    """Smoke: FE sends a ``data:image/png`` URL; gateway writes it to the
+    desktop_mate media dir and the agent loop drives a normal turn to
+    completion (stream_start → delta → stream_end).
+
+    We don't assert anything about provider payload shape here — the
+    in-process unit suite covers decode + forwarding deterministically;
+    the live flight is just the "end to end nothing blows up" gate.
+    """
+    client = await live_client(client_id="e2e-I")
+    await client.wait_for_event("ready", timeout=5.0)
+
+    await run_turn_and_drain(
+        client,
+        {
+            "type": "new_chat",
+            "content": "이 이미지를 한 문장으로 설명해 줘.",
+            "images": [_TINY_PNG_DATA_URL],
+            "tts_enabled": False,
+        },
+        drain_seconds=2.0,
+    )
+
+    events = client.events()
+    assert "image_rejected" not in events, events
+    assert "stream_start" in events and "stream_end" in events, events


### PR DESCRIPTION
## Summary

- Inbound `new_chat` / `message` frames now accept an optional `images: list[str]` field of `data:<mime>;base64,<payload>` URLs; entries are decoded via `nanobot.utils.media_decode.save_base64_data_url` under `get_media_dir("desktop_mate")` and forwarded as `media` paths through `BaseChannel._handle_message`, so the existing multimodal pipeline picks them up without further glue. Refs #8.
- Caps mirror upstream nanobot's built-in WS channel: 4 images/frame, 10 MB per decoded image, MIME allow-list `png/jpeg/webp/gif` (SVG excluded). Any failure rejects the whole turn and emits a new `image_rejected` frame with a stable reason token (`malformed` / `too_large` / `unsupported_mime`).
- Allows image-only turns (blank `content` + non-empty `images`) to match upstream `websocket.py:1043`; legacy text-only behavior is unchanged when the field is absent or `null`.

## Runtime component(s) touched

- [x] `DesktopMateChannel` (WS protocol / routing / REST)
- [ ] `TTSHook` (hooks/tts.py)
- [ ] TTS dependency impl (chunker / preprocessor / emotion mapper / synthesizer)
- [ ] `LTMInjectionHook` / `LTMArgumentsHook` / `LTMSavingConsolidator`
- [ ] `IdleScanner` / `install_idle_system_job`
- [ ] Gateway launcher (gateway.py, monkey-patch surface)
- [x] Tests (unit / integration / e2e)
- [x] Docs / setup / operations
- [ ] CI / tooling / dependencies

## nanobot-ai compatibility

Relies on two upstream-stable surfaces on `yw0nam/nanobot:develop` (pinned via `nanobot-ai>=0.1.5.post1` in `pyproject.toml`):

- `nanobot.utils.media_decode.save_base64_data_url(data_url, media_dir, max_bytes=...)` — decode-and-persist helper + `FileSizeExceeded`.
- `nanobot.channels.base.BaseChannel._handle_message(..., media=...)` — the kwarg that triggers the agent loop's multimodal conversion.
- `nanobot.config.paths.get_media_dir("desktop_mate")` — shared FS layout so media coexists with the built-in WS channel.

No new surface beyond what's already covered by the `_SUPPORTED_PREFIXES = ("0.1.5",)` assertion in `gateway.py`; no private / underscore attributes touched.

## Test plan

- [x] `uv run pytest` → 191 passed, 10 deselected (176 baseline + 15 new unit tests; `test(channels):` commit).
- [ ] `uv run pytest -m e2e` — new Scenario I added (`test_i_inbound_image_reaches_multimodal_pipeline` in `tests/e2e/test_live_scenarios.py`) but not executed here: requires live vLLM + LTM-MCP; deferred to an env that has those up.
- [x] Manual smoke — N/A for this PR; live path will be exercised by the Scenario I run once backends are available.

## Notes for reviewer

- `_max_image_bytes` is an instance attribute so tests can lower the cap without base64-encoding 10 MB of padding per case.
- `_media_dir` is lazily resolved via `get_media_dir("desktop_mate")`; tests override by assigning directly before invoking the inbound loop.
- Partial-ingress safety: on rejection, any images already written to disk earlier in the same frame are unlinked, matching upstream `_save_envelope_media` behavior.