### PR TITLE
refactor(channels): simplify and modularize nanobot_runtime

### DIFF
--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -2,7 +2,8 @@
 
 TTSSink routing: ``send_tts_chunk`` does not pass ``chat_id``. The channel
 tracks the currently active stream via ``(stream_id → (chat_id, conn))``
-registered on first ``send_delta`` and routes TTS chunks to the latest.
+registered on the first ``send_delta`` for a new stream, or on a
+``_stream_start``-tagged ``send()`` call. Routes TTS chunks to the latest.
 Stream entries are kept past ``stream_end`` so late TTS chunks (arriving
 via the TTS Barrier) still have a chat_id to route to.
 
@@ -222,6 +223,7 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
     ) -> None:
         conn = self._chat_conn.get(chat_id)
         if conn is None:
+            logger.warning("desktop_mate: send_delta: no connection for chat_id={}", chat_id)
             return
 
         meta = metadata or {}

--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -1,216 +1,57 @@
 """DesktopMateChannel — DMP-compatible WebSocket channel + TTSSink.
 
-Implements the FE WebSocket protocol documented in
-``nanobot-migration.md §8`` (outbound: ``stream_start`` / ``delta`` /
-``tts_chunk`` / ``stream_end`` + optional ``proactive: true``; inbound:
-``new_chat`` / ``message``). Also satisfies the ``TTSSink`` protocol
-defined in :mod:`nanobot_runtime.hooks.tts` so ``TTSHook`` can route
-synthesised audio frames through the same socket.
+TTSSink routing: ``send_tts_chunk`` does not pass ``chat_id``. The channel
+tracks the currently active stream via ``(stream_id → (chat_id, conn))``
+registered on first ``send_delta`` and routes TTS chunks to the latest.
+Stream entries are kept past ``stream_end`` so late TTS chunks (arriving
+via the TTS Barrier) still have a chat_id to route to.
 
-TTSSink chat_id routing
------------------------
-
-``TTSHook.send_tts_chunk(chunk)`` does not pass ``chat_id``. Nanobot's
-agent loop streams sequentially per session, so we track the *currently
-active stream* by recording ``(stream_id → (chat_id, connection))`` on
-the first ``send_delta`` for a given ``stream_id`` and clearing it on
-``stream_end``. ``send_tts_chunk`` always routes to the most recently
-registered stream.
-
-This slice keeps the server minimal. Auth is a single static token
-matched against ``?token=`` in the connection URL; JWT / rotating tokens
-are explicitly out of scope and can layer on later.
+Auth: single static token against ``?token=`` in the WS URL.
 """
 from __future__ import annotations
 
 import asyncio
-import binascii
 import re
 import time
 import uuid
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 from loguru import logger
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 from websockets.http11 import Request as WsRequest
-from websockets.http11 import Response
 
 from nanobot.bus.events import OutboundMessage
 from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
-from nanobot.utils.media_decode import FileSizeExceeded, save_base64_data_url
 
+from nanobot_runtime.channels.desktop_mate_config import DesktopMateConfig, _coerce_config
+from nanobot_runtime.channels.desktop_mate_image import _MAX_IMAGE_BYTES, _decode_images
 from nanobot_runtime.channels.desktop_mate_protocol import (
     DeltaFrame,
-    ImageRejectedFrame,
     ImageRejectReason,
-    MessageFrame,
-    NewChatFrame,
     ReadyFrame,
     StreamEndFrame,
     StreamStartFrame,
-    TTSChunkFrame,
-    _MAX_IMAGES_PER_MESSAGE,
-    parse_inbound,
 )
-from nanobot_runtime.channels.desktop_mate_rest import (
-    bearer_token,
-    decode_api_key,
-    http_error,
-    http_json_response,
-    is_websocket_upgrade,
-    parse_request_path,
-    query_first,
-)
+from nanobot_runtime.channels.desktop_mate_rest import dispatch_http, parse_request_path, query_first
+from nanobot_runtime.channels.desktop_mate_server import _DesktopMateServerMixin
+from nanobot_runtime.channels.desktop_mate_tts import _DesktopMateTTSMixin
 from nanobot_runtime.hooks.tts import TTSChunk
+from nanobot_runtime.tts.emotion_mapper import EmotionMapper
+
+# Re-export for callers that import DesktopMateConfig from this module.
+__all__ = ["DesktopMateConfig", "DesktopMateChannel", "LazyChannelTTSSink",
+           "get_desktop_mate_channel"]
 
 
 # ---------------------------------------------------------------------------
-# Config
+# Registry
 # ---------------------------------------------------------------------------
 
-
-@dataclass
-class DesktopMateConfig:
-    """Runtime configuration for :class:`DesktopMateChannel`.
-
-    The channel expects clients to connect at
-    ``ws://{host}:{port}{path}?token=<token>&client_id=<client_id>``.
-    ``token`` is compared against :attr:`token` using constant-time
-    equality. ``client_id`` populates the nanobot ``sender_id`` for
-    ``allow_from`` authorization.
-    """
-
-    enabled: bool = True
-    host: str = "127.0.0.1"
-    port: int = 8765
-    path: str = "/ws"
-    token: str = ""
-    allow_from: list[str] = field(default_factory=lambda: ["*"])
-    streaming: bool = True
-    # WS protocol-level keepalive (seconds). Set to None to disable.
-    ping_interval_s: float | None = 20.0
-    ping_timeout_s: float | None = 20.0
-    # Max inbound frame size in bytes.  Must be large enough to fit the
-    # worst-case image payload: _MAX_IMAGES_PER_MESSAGE (4) × _MAX_IMAGE_BYTES
-    # (10 MB) base64-encoded (×4/3) ≈ 53 MB.  60 MB gives headroom for JSON
-    # framing and future cap adjustments.
-    max_message_bytes: int = 60 * 1024 * 1024
-    # Path to the YAML file whose ``emotion_motion_map`` keys enumerate the
-    # emojis the channel should strip from outbound ``delta`` text. Same file
-    # the TTSHook loads for keyframe mapping — kept in sync naturally.
-    # When unset the channel does no stripping (tests explicitly inject the
-    # set via the ``emotion_emojis`` kwarg; production must point this at
-    # the workspace's ``tts_rules.yml``).
-    emotion_map_path: str | None = None
-
-
-# Accept either snake_case (internal) or camelCase (nanobot.json convention).
-_CAMEL_TO_SNAKE: dict[str, str] = {
-    "allowFrom": "allow_from",
-    "pingIntervalS": "ping_interval_s",
-    "pingTimeoutS": "ping_timeout_s",
-    "maxMessageBytes": "max_message_bytes",
-    "emotionMapPath": "emotion_map_path",
-}
-
-
-# Per-image ingress caps (issue #8). Matches upstream nanobot's built-in
-# WS channel intent: 10 MB per image is the user-facing ceiling, SVG is
-# excluded to avoid embedded-script XSS surface.
-_MAX_IMAGE_BYTES = 10 * 1024 * 1024
-_IMAGE_MIME_ALLOWED: frozenset[str] = frozenset({
-    "image/png",
-    "image/jpeg",
-    "image/webp",
-    "image/gif",
-})
-_DATA_URL_MIME_RE = re.compile(r"^data:([^;]+);base64,", re.DOTALL)
-
-
-def _extract_data_url_mime(url: str) -> str | None:
-    if not isinstance(url, str):
-        return None
-    m = _DATA_URL_MIME_RE.match(url)
-    if not m:
-        return None
-    return m.group(1).strip().lower() or None
-
-
-def _load_emotion_emojis_from_yaml(path: str) -> set[str]:
-    """Extract the keys of ``emotion_motion_map`` from a YAML file.
-
-    Shared source of truth with :class:`EmotionMapper.from_yaml`. Returns
-    an empty set on any load error — better to miss emoji stripping than
-    to crash gateway startup over a missing config file.
-    """
-    try:
-        import yaml
-
-        with open(path, "r", encoding="utf-8") as stream:
-            data = yaml.safe_load(stream) or {}
-    except (OSError, Exception) as e:  # noqa: BLE001 — tolerate any load error
-        logger.warning(
-            "desktop_mate: failed to load emotion map from {}: {}",
-            path,
-            e,
-        )
-        return set()
-    if not isinstance(data, dict):
-        return set()
-    mapping = data.get("emotion_motion_map", {})
-    if not isinstance(mapping, dict):
-        return set()
-    return {k for k in mapping if isinstance(k, str) and k != "default"}
-
-
-def _coerce_config(section: Any) -> DesktopMateConfig:
-    """Normalise a channel section into :class:`DesktopMateConfig`.
-
-    Accepts three shapes ChannelManager may emit:
-      * an existing ``DesktopMateConfig`` instance (used by tests and direct
-        Python callers) — returned unchanged;
-      * a dict parsed from ``nanobot.json`` (snake_case or camelCase);
-      * a pydantic-like section object — coerced via ``model_dump``.
-
-    Unknown keys are silently ignored so config file evolution doesn't
-    crash startup on a forgotten field.
-    """
-    if isinstance(section, DesktopMateConfig):
-        return section
-
-    if hasattr(section, "model_dump"):
-        raw: dict[str, Any] = section.model_dump()
-    elif isinstance(section, dict):
-        raw = dict(section)
-    else:
-        raw = {}
-
-    normalised: dict[str, Any] = {}
-    known = {f.name for f in DesktopMateConfig.__dataclass_fields__.values()}
-    for key, value in raw.items():
-        target = _CAMEL_TO_SNAKE.get(key, key)
-        if target in known:
-            normalised[target] = value
-    return DesktopMateConfig(**normalised)
-
-
-# ---------------------------------------------------------------------------
-# Channel
-# ---------------------------------------------------------------------------
-
-
-# Single-process registry for TTS sink lookup.
-#
-# ChannelManager builds the channel during gateway start-up, while hooks are
-# built per-AgentLoop. The two code paths don't share a reference, so the
-# channel registers itself here on construction and :class:`LazyChannelTTSSink`
-# resolves it at send time. In practice nanobot instantiates exactly one
-# DesktopMateChannel per process; repeat construction (e.g. hot reload or
-# test reruns) overwrites the entry.
+# Single-process registry so LazyChannelTTSSink can resolve the channel at
+# send time without a shared construction reference between the channel
+# manager and the hook factory.
 _LATEST_CHANNEL: "DesktopMateChannel | None" = None
 
 
@@ -230,7 +71,12 @@ def _reset_registry_for_tests() -> None:
     _LATEST_CHANNEL = None
 
 
-class DesktopMateChannel(BaseChannel):
+# ---------------------------------------------------------------------------
+# Channel
+# ---------------------------------------------------------------------------
+
+
+class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChannel):
     """WebSocket channel implementing the DMP-compatible FE protocol."""
 
     name = "desktop_mate"
@@ -248,50 +94,41 @@ class DesktopMateChannel(BaseChannel):
         super().__init__(coerced, bus)
         self.config: DesktopMateConfig = coerced
         # Injected by the gateway's ChannelManager monkey-patch; used by the
-        # REST routes below. ``None`` is tolerated so unit tests can construct
-        # the channel in isolation — the routes 503 in that case.
+        # REST routes. ``None`` is tolerated so unit tests can construct the
+        # channel in isolation — the routes 503 in that case.
         self._session_manager = session_manager
         global _LATEST_CHANNEL
         _LATEST_CHANNEL = self
-        # Emoji-stripping set: explicit kwarg (tests) wins, else load from
-        # config-specified YAML (production path). Empty set = no stripping.
+        # Emoji-stripping: explicit kwarg (tests) wins over config YAML.
         if emotion_emojis is not None:
-            self._emotion_emojis = set(emotion_emojis)
+            self._emotion_emojis: frozenset[str] = frozenset(emotion_emojis)
         elif coerced.emotion_map_path:
-            self._emotion_emojis = _load_emotion_emojis_from_yaml(
-                coerced.emotion_map_path
-            )
+            self._emotion_emojis = EmotionMapper.from_yaml(coerced.emotion_map_path).known_emojis
         else:
-            self._emotion_emojis = set()
-        # chat_id -> connection (1 connection per chat in desktop-mate's 1:1 model)
+            self._emotion_emojis = frozenset()
+        self._emotion_strip_re: re.Pattern[str] | None = (
+            re.compile("|".join(re.escape(e) for e in self._emotion_emojis))
+            if self._emotion_emojis else None
+        )
         self._chat_conn: dict[str, Any] = {}
-        # stream_id -> (chat_id, proactive flag) for TTSSink routing
         self._streams: dict[str, tuple[str, bool]] = {}
-        # Most recently registered stream_id — used as "current" for send_tts_chunk
         self._current_stream_id: str | None = None
         # TTS enable/disable state (MVP — channel-side short-circuit only;
-        # synthesis still runs. See migration-todo §3-C.α for the
-        # synthesis-skip follow-up that removes the wasted work).
+        # synthesis still runs. See migration-todo §3-C.α).
         # chat_id -> bool; absent == True (default enabled).
         self._tts_enabled_per_chat: dict[str, bool] = {}
-        # connection identity -> bool; takes precedence over per-chat flags
-        # so URL ``?tts=0`` overrides per-message toggles for the whole
-        # socket. Connection objects are hashable; we key on id() to avoid
-        # relying on their __hash__ implementation.
+        # connection id() -> bool; takes precedence over per-chat flags
+        # so URL ``?tts=0`` overrides per-message toggles for the whole socket.
         self._tts_enabled_per_conn: dict[int, bool] = {}
-        # Server state
         self._stop_event: asyncio.Event | None = None
         self._server_task: asyncio.Task[None] | None = None
         self._server: Any | None = None
-        # Per-image byte cap — exposed as an instance attr so tests can
-        # dial it down without base64-encoding 10 MB of padding per case.
+        # Per-image byte cap — instance attr so tests can dial it down.
         self._max_image_bytes: int = _MAX_IMAGE_BYTES
-        # Media directory for decoded inbound images. Resolved lazily via
-        # :meth:`_resolve_media_dir` so tests can override by assigning
-        # ``channel._media_dir`` before triggering the inbound loop.
+        # Media directory resolved lazily; tests can override by assigning _media_dir.
         self._media_dir: Path | None = None
 
-    # -- Subscription bookkeeping ------------------------------------------
+    # -- Connection bookkeeping --------------------------------------------
 
     def _attach(self, chat_id: str, connection: Any) -> None:
         self._chat_conn[chat_id] = connection
@@ -302,7 +139,6 @@ class DesktopMateChannel(BaseChannel):
                 self._chat_conn.pop(cid, None)
                 self._tts_enabled_per_chat.pop(cid, None)
         self._tts_enabled_per_conn.pop(id(connection), None)
-        # Drop any streams whose chat is gone.
         for sid, (cid, _) in list(self._streams.items()):
             if cid not in self._chat_conn:
                 self._streams.pop(sid, None)
@@ -312,19 +148,11 @@ class DesktopMateChannel(BaseChannel):
     # -- Image intake ------------------------------------------------------
 
     def _resolve_media_dir(self) -> Path:
-        """Return the directory inbound images are persisted to.
-
-        Uses nanobot's ``get_media_dir("desktop_mate")`` so the FS layout
-        matches the built-in WS channel. Lazy-evaluated so construction
-        order (channel-first vs config-first) doesn't matter.
-        """
         if self._media_dir is not None:
             return self._media_dir
         from nanobot.config.paths import get_media_dir
-
-        resolved = get_media_dir("desktop_mate")
-        self._media_dir = resolved
-        return resolved
+        self._media_dir = get_media_dir("desktop_mate")
+        return self._media_dir
 
     def _decode_inbound_images(
         self,
@@ -332,154 +160,14 @@ class DesktopMateChannel(BaseChannel):
         *,
         sender_id: str,
     ) -> tuple[list[str], ImageRejectReason | None]:
-        """Decode a frame's ``images`` entries to disk.
-
-        Returns ``(paths, None)`` on success or ``([], reason)`` on the
-        first failure (whole turn rejected — no partial ingress). Every
-        rejection is logged with ``sender_id`` + mime + size so MIME
-        violations (a potential XSS / XXE surface) and server-side IO
-        failures are observable to ops. ``ImageRejectReason`` is the
-        closed set documented on :class:`ImageRejectedFrame`.
-        """
-        if not images:
-            return [], None
-
-        if len(images) > _MAX_IMAGES_PER_MESSAGE:
-            logger.warning(
-                "desktop_mate: rejecting inbound images from {}: "
-                "count={} exceeds cap={} (reason=too_many)",
-                sender_id, len(images), _MAX_IMAGES_PER_MESSAGE,
-            )
-            return [], "too_many"
-
-        media_dir = self._resolve_media_dir()
-        saved_paths: list[str] = []
-
-        def _abort(
-            reason: ImageRejectReason,
-            *,
-            mime: str | None = None,
-            size_hint: int | None = None,
-        ) -> tuple[list[str], ImageRejectReason]:
-            # io_error is a server-side failure (disk full, permission,
-            # media dir gone); everything else is caller-fixable.
-            level = "error" if reason == "io_error" else "warning"
-            getattr(logger, level)(
-                "desktop_mate: rejecting inbound image from {}: "
-                "reason={} mime={} size_hint={}",
-                sender_id, reason, mime, size_hint,
-            )
-            # Any image already written before a later entry fails must be
-            # unlinked — partial state on disk confuses downstream cleanup.
-            for p in saved_paths:
-                try:
-                    Path(p).unlink(missing_ok=True)
-                except OSError as exc:
-                    logger.warning(
-                        "desktop_mate: failed to unlink partial media {}: {}",
-                        p, exc,
-                    )
-            return [], reason
-
-        for entry in images:
-            if not isinstance(entry, str) or not entry:
-                return _abort("malformed")
-            mime = _extract_data_url_mime(entry)
-            if mime is None:
-                return _abort("malformed")
-            if mime not in _IMAGE_MIME_ALLOWED:
-                return _abort("unsupported_mime", mime=mime)
-            try:
-                saved = save_base64_data_url(
-                    entry, media_dir, max_bytes=self._max_image_bytes,
-                )
-            except FileSizeExceeded:
-                return _abort("too_large", mime=mime, size_hint=len(entry))
-            except (binascii.Error, ValueError) as exc:
-                # Malformed base64 / bad data URL payload. Caller-fixable.
-                logger.debug(
-                    "desktop_mate: decode failed (caller-fixable): {}", exc
-                )
-                return _abort("malformed", mime=mime, size_hint=len(entry))
-            except OSError as exc:
-                # Disk write failure (full FS, permission, missing dir).
-                # Server-side problem — surface as io_error so FE can
-                # retry rather than blame the user's image.
-                logger.opt(exception=True).error(
-                    "desktop_mate: image persist failed: {}", exc
-                )
-                return _abort("io_error", mime=mime, size_hint=len(entry))
-            if saved is None:
-                return _abort("malformed", mime=mime, size_hint=len(entry))
-            saved_paths.append(saved)
-        return saved_paths, None
-
-    # -- TTS policy --------------------------------------------------------
-
-    @staticmethod
-    def _parse_bool_flag(value: str | None) -> bool | None:
-        """Parse ``?tts=<value>`` into a tri-state: True / False / None (no override)."""
-        if value is None:
-            return None
-        v = value.strip().lower()
-        if v in ("0", "false", "off", "no"):
-            return False
-        if v in ("1", "true", "on", "yes"):
-            return True
-        return None
-
-    def _apply_connection_tts_override(
-        self, connection: Any, query: dict[str, list[str]]
-    ) -> None:
-        """Read the URL ``tts`` param during handshake and record per-connection policy."""
-        values = query.get("tts") or []
-        flag = self._parse_bool_flag(values[0] if values else None)
-        if flag is None:
-            return
-        self._tts_enabled_per_conn[id(connection)] = flag
-
-    def _tts_enabled_for_chat(self, chat_id: str) -> bool:
-        """Effective policy: connection override wins over per-chat flag; default True."""
-        conn = self._chat_conn.get(chat_id)
-        if conn is not None:
-            conn_flag = self._tts_enabled_per_conn.get(id(conn))
-            if conn_flag is not None:
-                return conn_flag
-        return self._tts_enabled_per_chat.get(chat_id, True)
-
-    def is_tts_enabled_for_current_stream(self) -> bool:
-        """Public accessor for :class:`LazyChannelTTSSink`.
-
-        Returns ``False`` whenever no desktop_mate stream is currently
-        registered. This is the gate that keeps TTSHook from synthesising
-        for turns running on *other* channels (e.g. the Phase-5 idle
-        watcher firing through ``channel=cli``): those turns never set
-        ``_current_stream_id`` on this channel, so we correctly decline
-        to emit audio for them.
-
-        The previous default (``True`` when no stream) was a holdover from
-        a single-channel assumption that Phase 5 broke. See
-        migration-todo §3-D (Scenario C regression) and the tts.py
-        "Per-session state" section.
-        """
-        stream_id = self._current_stream_id
-        if stream_id is None:
-            return False
-        info = self._streams.get(stream_id)
-        if info is None:
-            return False
-        chat_id, _ = info
-        return self._tts_enabled_for_chat(chat_id)
+        return _decode_images(
+            images,
+            sender_id=sender_id,
+            media_dir=self._resolve_media_dir(),
+            max_image_bytes=self._max_image_bytes,
+        )
 
     # -- Frame helpers -----------------------------------------------------
-
-    def _strip_emotions(self, text: str) -> str:
-        if not self._emotion_emojis:
-            return text
-        out = text
-        for emoji in self._emotion_emojis:
-            out = out.replace(emoji, "")
-        return out
 
     async def _send_frame(self, connection: Any, frame: BaseModel) -> None:
         raw = frame.model_dump_json(exclude_none=True)
@@ -494,18 +182,13 @@ class DesktopMateChannel(BaseChannel):
         connection_id = str(uuid.uuid4())
         await self._send_frame(
             connection,
-            ReadyFrame(
-                connection_id=connection_id,
-                client_id=client_id,
-                server_time=time.time(),
-            ),
+            ReadyFrame(connection_id=connection_id, client_id=client_id, server_time=time.time()),
         )
         return connection_id
 
-    # -- BaseChannel.send --------------------------------------------------
+    # -- Outbound ----------------------------------------------------------
 
     async def send(self, msg: OutboundMessage) -> None:
-        """Dispatch an outbound nanobot message to the correct DMP frame."""
         conn = self._chat_conn.get(msg.chat_id)
         if conn is None:
             logger.warning("desktop_mate: no connection for chat_id={}", msg.chat_id)
@@ -519,29 +202,17 @@ class DesktopMateChannel(BaseChannel):
             if stream_id:
                 self._streams[stream_id] = (msg.chat_id, bool(proactive_flag))
                 self._current_stream_id = stream_id
-            await self._send_frame(
-                conn,
-                StreamStartFrame(chat_id=msg.chat_id, proactive=proactive_flag),
-            )
+            await self._send_frame(conn, StreamStartFrame(chat_id=msg.chat_id, proactive=proactive_flag))
             return
 
-        # Fallback and explicit _stream_end both serialise as stream_end.
-        # Note: we deliberately do NOT clear ``_streams[stream_id]`` or
-        # ``_current_stream_id`` here. TTS synthesis runs concurrently with
-        # the agent loop; a ``tts_chunk`` may arrive via the hook's TTS
-        # Barrier **after** nanobot's manager has already dispatched
-        # ``_stream_end`` through the bus. Stream entries are cleared only
-        # when a new stream replaces them or the connection drops.
+        # We deliberately do NOT clear stream state here — TTS synthesis runs
+        # concurrently and a tts_chunk may arrive after stream_end via the TTS
+        # Barrier. Stream entries are cleared only when a new stream registers
+        # or the connection drops.
         await self._send_frame(
             conn,
-            StreamEndFrame(
-                chat_id=msg.chat_id,
-                content=msg.content,
-                proactive=proactive_flag,
-            ),
+            StreamEndFrame(chat_id=msg.chat_id, content=msg.content, proactive=proactive_flag),
         )
-
-    # -- BaseChannel.send_delta --------------------------------------------
 
     async def send_delta(
         self,
@@ -557,31 +228,18 @@ class DesktopMateChannel(BaseChannel):
         stream_id = meta.get("_stream_id")
         proactive_flag: bool | None = True if meta.get("proactive") else None
 
-        # First delta for a new stream: register the routing entry AND
-        # auto-emit a ``stream_start`` frame. Nanobot's channel manager
-        # never sets a ``_stream_start`` metadata itself, so without this
-        # the FE never sees the turn boundary.
-        is_new_stream = bool(stream_id) and stream_id not in self._streams
-        if is_new_stream:
+        # First delta for a new stream: register routing entry AND auto-emit
+        # stream_start. Nanobot's channel manager never sets _stream_start
+        # metadata itself, so without this the FE never sees the turn boundary.
+        if bool(stream_id) and stream_id not in self._streams:
             self._streams[stream_id] = (chat_id, bool(proactive_flag))
             self._current_stream_id = stream_id
-            await self._send_frame(
-                conn,
-                StreamStartFrame(chat_id=chat_id, proactive=proactive_flag),
-            )
+            await self._send_frame(conn, StreamStartFrame(chat_id=chat_id, proactive=proactive_flag))
 
-        # _stream_end is routed here by nanobot's channel manager when it
-        # coalesces. We deliberately keep stream state so a ``tts_chunk``
-        # arriving via the TTS Barrier after stream_end still has a
-        # chat_id to route to (see :meth:`send`).
         if meta.get("_stream_end"):
             await self._send_frame(
                 conn,
-                StreamEndFrame(
-                    chat_id=chat_id,
-                    content=delta,
-                    proactive=proactive_flag,
-                ),
+                StreamEndFrame(chat_id=chat_id, content=delta, proactive=proactive_flag),
             )
             return
 
@@ -595,157 +253,22 @@ class DesktopMateChannel(BaseChannel):
             ),
         )
 
-    # -- TTSSink -----------------------------------------------------------
-
-    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
-        """Emit a ``tts_chunk`` frame for the currently streaming chat."""
-        stream_id = self._current_stream_id
-        if stream_id is None or stream_id not in self._streams:
-            logger.warning(
-                "desktop_mate: send_tts_chunk with no active stream (seq={}); dropping",
-                chunk.sequence,
-            )
-            return
-        chat_id, proactive = self._streams[stream_id]
-        conn = self._chat_conn.get(chat_id)
-        if conn is None:
-            logger.warning("desktop_mate: tts_chunk target gone (chat_id={})", chat_id)
-            return
-
-        # Short-circuit when TTS is disabled for this chat/connection.
-        # Synthesis still happened upstream (MVP trade-off — see
-        # migration-todo §3-C.α). Dropping here still saves the FE from
-        # decoding and playing audio on a muted client.
-        if not self._tts_enabled_for_chat(chat_id):
-            return
-
-        await self._send_frame(
-            conn,
-            TTSChunkFrame(
-                chat_id=chat_id,
-                sequence=chunk.sequence,
-                text=chunk.text,
-                audio_base64=chunk.audio_base64,
-                emotion=chunk.emotion,
-                keyframes=list(chunk.keyframes),
-                proactive=True if proactive else None,
-            ),
-        )
-
     # -- REST surface ------------------------------------------------------
 
-    _SESSION_KEY_PREFIX = "desktop_mate:"
-
     async def _dispatch_http(self, connection: Any, request: WsRequest) -> Any:
-        """Route an inbound HTTP request to a REST handler or fall through to WS.
-
-        Returning ``None`` lets the ``websockets`` library proceed with the
-        WebSocket handshake; returning a :class:`Response` short-circuits
-        with an HTTP reply.
-        """
-        got, _query = parse_request_path(request.path)
-
-        if got == "/api/sessions":
-            return self._handle_sessions_list(request)
-
-        m = re.match(r"^/api/sessions/([^/]+)/messages$", got)
-        if m:
-            return self._handle_session_messages(request, m.group(1))
-
-        # websockets' HTTP parser only supports GET, so delete is path-folded.
-        m = re.match(r"^/api/sessions/([^/]+)/delete$", got)
-        if m:
-            return self._handle_session_delete(request, m.group(1))
-
-        # Let the WS handshake path through.
-        expected_ws = self.config.path.rstrip("/") or "/"
-        if got == expected_ws and is_websocket_upgrade(request):
-            return None
-
-        return http_error(404, "Not Found")
-
-    def _check_rest_token(self, request: WsRequest) -> bool:
-        """Validate the REST request against the channel's static token.
-
-        Accepts ``Authorization: Bearer <token>`` header or ``?token=<token>``
-        query string. When no token is configured (dev / loopback), every
-        request is allowed — mirroring ``_authorize_token``.
-        """
-        expected = (self.config.token or "").strip()
-        if not expected:
-            return True
-        _, query = parse_request_path(request.path)
-        supplied = bearer_token(request.headers) or query_first(query, "token")
-        return supplied is not None and supplied == expected
-
-    def _is_desktop_mate_key(self, key: str) -> bool:
-        return key.startswith(self._SESSION_KEY_PREFIX)
-
-    def _handle_sessions_list(self, request: WsRequest) -> Response:
-        if not self._check_rest_token(request):
-            return http_error(401, "Unauthorized")
-        if self._session_manager is None:
-            return http_error(503, "session manager unavailable")
-        sessions = self._session_manager.list_sessions()
-        # Filter to our own channel's sessions and strip absolute paths —
-        # the FE doesn't need filesystem layout.
-        cleaned = [
-            {k: v for k, v in s.items() if k != "path"}
-            for s in sessions
-            if isinstance(s.get("key"), str)
-            and self._is_desktop_mate_key(s["key"])
-        ]
-        return http_json_response({"sessions": cleaned})
-
-    def _handle_session_messages(self, request: WsRequest, key: str) -> Response:
-        if not self._check_rest_token(request):
-            return http_error(401, "Unauthorized")
-        if self._session_manager is None:
-            return http_error(503, "session manager unavailable")
-        decoded = decode_api_key(key)
-        if decoded is None:
-            return http_error(400, "invalid session key")
-        if not self._is_desktop_mate_key(decoded):
-            return http_error(404, "session not found")
-        data = self._session_manager.read_session_file(decoded)
-        if data is None:
-            return http_error(404, "session not found")
-        return http_json_response(data)
-
-    def _handle_session_delete(self, request: WsRequest, key: str) -> Response:
-        if not self._check_rest_token(request):
-            return http_error(401, "Unauthorized")
-        if self._session_manager is None:
-            return http_error(503, "session manager unavailable")
-        decoded = decode_api_key(key)
-        if decoded is None:
-            return http_error(400, "invalid session key")
-        if not self._is_desktop_mate_key(decoded):
-            return http_error(404, "session not found")
-        deleted = self._session_manager.delete_session(decoded)
-        return http_json_response({"deleted": bool(deleted)})
+        return dispatch_http(self.config.token, self._session_manager, self.config.path, request)
 
     # -- Auth / handshake --------------------------------------------------
 
     def _authorize_token(self, supplied: str | None) -> bool:
         expected = (self.config.token or "").strip()
         if not expected:
-            # No token configured — allow (trusted dev loopback only).
             return True
-        if not supplied:
-            return False
-        # hmac.compare_digest-ish; plain equality is fine for a dev-static
-        # token but we avoid early exit on length to keep the intent clear.
-        return supplied == expected
+        return bool(supplied) and supplied == expected
 
     async def _handshake(self, connection: Any, query: dict[str, list[str]]) -> bool:
-        """Validate ``?token=`` and close with 4003 on failure.
-
-        Returns True when the connection should proceed to the main loop.
-        """
-        token_values = query.get("token") or []
-        supplied = token_values[0] if token_values else None
-        if not self._authorize_token(supplied):
+        """Validate ``?token=`` and close with 4003 on failure."""
+        if not self._authorize_token(query_first(query, "token")):
             try:
                 await connection.close(code=4003, reason="invalid token")
             except Exception as e:
@@ -753,214 +276,29 @@ class DesktopMateChannel(BaseChannel):
             return False
         return True
 
-    # -- Inbound loop ------------------------------------------------------
 
-    async def _connection_loop(
-        self,
-        connection: Any,
-        *,
-        sender_id: str,
-        default_chat_id: str | None = None,
-    ) -> None:
-        """Consume inbound frames, dispatching ``new_chat`` / ``message``."""
-        async for raw in connection:
-            if isinstance(raw, bytes):
-                try:
-                    raw = raw.decode("utf-8")
-                except UnicodeDecodeError:
-                    logger.warning("desktop_mate: non-utf8 binary frame, ignored")
-                    continue
-
-            try:
-                envelope = parse_inbound(raw)
-            except (ValidationError, ValueError) as e:
-                logger.warning(
-                    "desktop_mate: bad inbound frame, ignored: {} ({!r})",
-                    e,
-                    raw[:100],
-                )
-                continue
-
-            base_metadata: dict[str, Any] = {
-                "tts_enabled": envelope.tts_enabled,
-                "reference_id": envelope.reference_id,
-                "remote": getattr(connection, "remote_address", None),
-            }
-
-            if isinstance(envelope, NewChatFrame):
-                chat_id = str(uuid.uuid4())
-            else:
-                assert isinstance(envelope, MessageFrame)
-                chat_id = envelope.chat_id
-
-            media_paths, reject_reason = self._decode_inbound_images(
-                envelope.images, sender_id=sender_id,
-            )
-            if reject_reason is not None:
-                # new_chat rejections carry no chat_id — the session was
-                # never created. FE correlates via ``reference_id`` instead
-                # when it needs to match the rejection to its pending send.
-                await self._send_frame(
-                    connection,
-                    ImageRejectedFrame(
-                        chat_id=chat_id if isinstance(envelope, MessageFrame)
-                        else None,
-                        reason=reject_reason,
-                        reference_id=envelope.reference_id,
-                    ),
-                )
-                continue
-
-            self._attach(chat_id, connection)
-            # Record per-chat TTS policy from the inbound flag. Connection
-            # URL override (``?tts=0``) still wins in ``_tts_enabled_for_chat``.
-            self._tts_enabled_per_chat[chat_id] = bool(envelope.tts_enabled)
-            # Hand-off to the bus. If this raises (or the allow_from check
-            # inside silently rejects), decoded image files would leak on
-            # disk; unlink them on any non-happy exit. We don't propagate
-            # the exception — the connection should keep serving further
-            # frames from the same client.
-            try:
-                await self._handle_message(
-                    sender_id=sender_id,
-                    chat_id=chat_id,
-                    content=envelope.content,
-                    media=media_paths or None,
-                    metadata=base_metadata,
-                )
-            except Exception as exc:
-                logger.opt(exception=True).error(
-                    "desktop_mate: handle_message failed (chat_id={}): {}",
-                    chat_id, exc,
-                )
-                for p in media_paths:
-                    try:
-                        Path(p).unlink(missing_ok=True)
-                    except OSError as unlink_exc:
-                        logger.warning(
-                            "desktop_mate: leaked media {} "
-                            "(unlink after handle_message failure): {}",
-                            p, unlink_exc,
-                        )
-
-    # -- Server lifecycle --------------------------------------------------
-
-    async def start(self) -> None:
-        """Bind the WS server and serve until :meth:`stop` is called.
-
-        This uses the minimum viable ``websockets`` serve loop. Production
-        concerns (backpressure, SSL, per-connection timeouts, token rotation)
-        are explicitly deferred to a follow-up slice.
-        """
-        import websockets
-        from websockets.asyncio.server import serve
-
-        self._running = True
-        self._stop_event = asyncio.Event()
-
-        async def handler(connection: Any) -> None:
-            request = getattr(connection, "request", None)
-            raw_path = request.path if request else "/"
-            parsed = urlparse("ws://x" + raw_path)
-            query = parse_qs(parsed.query)
-
-            accepted = await self._handshake(connection, query)
-            if not accepted:
-                return
-
-            client_id_vals = query.get("client_id") or []
-            client_id = (client_id_vals[0] if client_id_vals else "").strip()
-            if not client_id:
-                client_id = f"anon-{uuid.uuid4().hex[:12]}"
-            if not self.is_allowed(client_id):
-                try:
-                    await connection.close(code=4003, reason="forbidden")
-                except Exception:
-                    pass
-                return
-
-            self._apply_connection_tts_override(connection, query)
-            await self._send_ready(connection, client_id=client_id)
-
-            try:
-                await self._connection_loop(connection, sender_id=client_id)
-            except Exception as e:
-                logger.debug("desktop_mate: connection loop ended: {}", e)
-            finally:
-                self._detach_connection(connection)
-
-        logger.info(
-            "desktop_mate: listening on ws://{}:{}{}",
-            self.config.host,
-            self.config.port,
-            self.config.path,
-        )
-
-        async def process_request(connection: Any, request: WsRequest) -> Any:
-            return await self._dispatch_http(connection, request)
-
-        async def runner() -> None:
-            async with serve(
-                handler,
-                self.config.host,
-                self.config.port,
-                process_request=process_request,
-                ping_interval=self.config.ping_interval_s,
-                ping_timeout=self.config.ping_timeout_s,
-                max_size=self.config.max_message_bytes,
-            ) as server:
-                self._server = server
-                assert self._stop_event is not None
-                await self._stop_event.wait()
-
-        self._server_task = asyncio.create_task(runner())
-        try:
-            await self._server_task
-        except asyncio.CancelledError:
-            raise
-
-    async def stop(self) -> None:
-        if not self._running:
-            return
-        self._running = False
-        if self._stop_event is not None:
-            self._stop_event.set()
-        if self._server_task is not None:
-            try:
-                await asyncio.wait_for(self._server_task, timeout=2.0)
-            except (asyncio.TimeoutError, Exception) as e:
-                logger.debug("desktop_mate: server task cleanup: {}", e)
-                self._server_task.cancel()
-            self._server_task = None
-        self._chat_conn.clear()
-        self._streams.clear()
-        self._current_stream_id = None
+# ---------------------------------------------------------------------------
+# Lazy TTS sink
+# ---------------------------------------------------------------------------
 
 
 class LazyChannelTTSSink:
     """TTSSink that resolves the active DesktopMateChannel at send time.
 
-    ``TTSHook`` takes a sink at construction, but the channel is created
-    later on a different code path. Doing the lookup lazily (per-chunk)
-    avoids ordering constraints. If the channel isn't available yet the
-    chunk is silently dropped — the agent loop stays healthy and FE will
-    simply miss TTS for that window.
+    Avoids ordering constraints between hook factory and channel construction.
+    If the channel isn't available yet, chunks are silently dropped — the
+    agent loop stays healthy and the FE misses TTS for that window.
     """
 
     def is_enabled(self) -> bool:
-        """Return the current stream's TTS policy, or True if no channel
-        has been constructed yet (safe default — hook does useful work).
-        """
         try:
-            channel = get_desktop_mate_channel()
+            return get_desktop_mate_channel().is_tts_enabled_for_current_stream()
         except RuntimeError:
-            return True
-        return channel.is_tts_enabled_for_current_stream()
+            return True  # No channel yet — allow hook to do useful work.
 
     async def send_tts_chunk(self, chunk: TTSChunk) -> None:
         try:
             channel = get_desktop_mate_channel()
         except RuntimeError:
-            # Channel not constructed yet — drop silently.
             return
         await channel.send_tts_chunk(chunk)

--- a/src/nanobot_runtime/channels/desktop_mate_config.py
+++ b/src/nanobot_runtime/channels/desktop_mate_config.py
@@ -1,0 +1,79 @@
+"""Config dataclass and helpers for DesktopMateChannel."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DesktopMateConfig:
+    """Runtime configuration for DesktopMateChannel.
+
+    Clients connect at ``ws://{host}:{port}{path}?token=<token>&client_id=<id>``.
+    ``token`` is checked with constant-time equality; ``client_id`` becomes the
+    nanobot ``sender_id`` for ``allow_from`` authorization.
+    """
+
+    enabled: bool = True
+    host: str = "127.0.0.1"
+    port: int = 8765
+    path: str = "/ws"
+    token: str = ""
+    allow_from: list[str] = field(default_factory=lambda: ["*"])
+    streaming: bool = True
+    ping_interval_s: float | None = 20.0
+    ping_timeout_s: float | None = 20.0
+    # Must fit _MAX_IMAGES_PER_MESSAGE × _MAX_IMAGE_BYTES base64-encoded (×4/3)
+    # ≈ 53 MB. 60 MB gives headroom for JSON framing.
+    max_message_bytes: int = 60 * 1024 * 1024
+    # Path to the YAML file whose ``emotion_motion_map`` keys enumerate the
+    # emojis to strip from outbound ``delta`` text.
+    emotion_map_path: str | None = None
+
+
+# Accept either snake_case (internal) or camelCase (nanobot.json convention).
+_CAMEL_TO_SNAKE: dict[str, str] = {
+    "allowFrom": "allow_from",
+    "pingIntervalS": "ping_interval_s",
+    "pingTimeoutS": "ping_timeout_s",
+    "maxMessageBytes": "max_message_bytes",
+    "emotionMapPath": "emotion_map_path",
+}
+
+
+def _coerce_config(section: Any) -> DesktopMateConfig:
+    """Normalise a channel section into DesktopMateConfig.
+
+    Accepts an existing instance (returned unchanged), a dict from
+    ``nanobot.json`` (snake_case or camelCase), or a pydantic-like object.
+    Unknown keys are silently ignored.
+    """
+    if isinstance(section, DesktopMateConfig):
+        return section
+
+    if hasattr(section, "model_dump"):
+        raw: dict[str, Any] = section.model_dump()
+    elif isinstance(section, dict):
+        raw = dict(section)
+    else:
+        raw = {}
+
+    known = {f.name for f in DesktopMateConfig.__dataclass_fields__.values()}
+    normalised: dict[str, Any] = {}
+    for key, value in raw.items():
+        target = _CAMEL_TO_SNAKE.get(key, key)
+        if target in known:
+            normalised[target] = value
+    return DesktopMateConfig(**normalised)
+
+
+def _parse_bool_flag(value: str | None) -> bool | None:
+    """Parse a URL query value into True / False / None (absent = no override)."""
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if v in ("0", "false", "off", "no"):
+        return False
+    if v in ("1", "true", "on", "yes"):
+        return True
+    return None

--- a/src/nanobot_runtime/channels/desktop_mate_config.py
+++ b/src/nanobot_runtime/channels/desktop_mate_config.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from loguru import logger
+
 
 @dataclass
 class DesktopMateConfig:
     """Runtime configuration for DesktopMateChannel.
 
     Clients connect at ``ws://{host}:{port}{path}?token=<token>&client_id=<id>``.
-    ``token`` is checked with constant-time equality; ``client_id`` becomes the
-    nanobot ``sender_id`` for ``allow_from`` authorization.
+    ``token`` is matched with plain string equality (not constant-time);
+    ``client_id`` becomes the nanobot ``sender_id`` for ``allow_from`` authorization.
     """
 
     enabled: bool = True
@@ -56,6 +58,10 @@ def _coerce_config(section: Any) -> DesktopMateConfig:
     elif isinstance(section, dict):
         raw = dict(section)
     else:
+        logger.warning(
+            "desktop_mate: unrecognised config type %s — using defaults",
+            type(section).__name__,
+        )
         raw = {}
 
     known = {f.name for f in DesktopMateConfig.__dataclass_fields__.values()}

--- a/src/nanobot_runtime/channels/desktop_mate_image.py
+++ b/src/nanobot_runtime/channels/desktop_mate_image.py
@@ -1,0 +1,111 @@
+"""Image decode and validation logic for DesktopMateChannel (issue #8).
+
+Validates count, MIME type, size, and base64 integrity; persists decoded
+images to the media directory. Every failure surfaces to the caller as an
+``ImageRejectReason`` token so the FE can handle it without parsing prose.
+"""
+from __future__ import annotations
+
+import binascii
+import re
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nanobot.utils.media_decode import FileSizeExceeded, save_base64_data_url
+
+from nanobot_runtime.channels.desktop_mate_protocol import (
+    ImageRejectReason,
+    _MAX_IMAGES_PER_MESSAGE,
+)
+
+
+# 10 MB per image — mirrors upstream nanobot's built-in WS channel intent.
+_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+# SVG is excluded to avoid embedded-script XSS surface.
+_IMAGE_MIME_ALLOWED: frozenset[str] = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+})
+
+_DATA_URL_MIME_RE = re.compile(r"^data:([^;]+);base64,", re.DOTALL)
+
+
+def _extract_data_url_mime(url: str) -> str | None:
+    if not isinstance(url, str):
+        return None
+    m = _DATA_URL_MIME_RE.match(url)
+    if not m:
+        return None
+    return m.group(1).strip().lower() or None
+
+
+def _decode_images(
+    images: list[str] | None,
+    *,
+    sender_id: str,
+    media_dir: Path,
+    max_image_bytes: int,
+) -> tuple[list[str], ImageRejectReason | None]:
+    """Decode a frame's ``images`` entries to disk.
+
+    Returns ``(paths, None)`` on success or ``([], reason)`` on the first
+    failure. Whole turn is rejected on any failure — no partial ingress.
+    Any images already written before a later failure are unlinked.
+    """
+    if not images:
+        return [], None
+
+    if len(images) > _MAX_IMAGES_PER_MESSAGE:
+        logger.warning(
+            "desktop_mate: rejecting images from {}: count={} exceeds cap={}",
+            sender_id, len(images), _MAX_IMAGES_PER_MESSAGE,
+        )
+        return [], "too_many"
+
+    saved_paths: list[str] = []
+
+    def _abort(
+        reason: ImageRejectReason,
+        *,
+        mime: str | None = None,
+        size_hint: int | None = None,
+    ) -> tuple[list[str], ImageRejectReason]:
+        level = "error" if reason == "io_error" else "warning"
+        getattr(logger, level)(
+            "desktop_mate: rejecting image from {}: reason={} mime={} size_hint={}",
+            sender_id, reason, mime, size_hint,
+        )
+        for p in saved_paths:
+            try:
+                Path(p).unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("desktop_mate: failed to unlink partial media {}: {}", p, exc)
+        return [], reason
+
+    for entry in images:
+        if not isinstance(entry, str) or not entry:
+            return _abort("malformed")
+        mime = _extract_data_url_mime(entry)
+        if mime is None:
+            return _abort("malformed")
+        if mime not in _IMAGE_MIME_ALLOWED:
+            return _abort("unsupported_mime", mime=mime)
+        try:
+            saved = save_base64_data_url(entry, media_dir, max_bytes=max_image_bytes)
+        except FileSizeExceeded:
+            return _abort("too_large", mime=mime, size_hint=len(entry))
+        except (binascii.Error, ValueError) as exc:
+            logger.debug("desktop_mate: decode failed (caller-fixable): {}", exc)
+            return _abort("malformed", mime=mime, size_hint=len(entry))
+        except OSError as exc:
+            logger.opt(exception=True).error("desktop_mate: image persist failed: {}", exc)
+            return _abort("io_error", mime=mime, size_hint=len(entry))
+        if saved is None:
+            return _abort("malformed", mime=mime, size_hint=len(entry))
+        saved_paths.append(saved)
+    return saved_paths, None

--- a/src/nanobot_runtime/channels/desktop_mate_rest.py
+++ b/src/nanobot_runtime/channels/desktop_mate_rest.py
@@ -20,6 +20,8 @@ import re
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
+from loguru import logger
+
 from websockets.datastructures import Headers
 from websockets.http11 import Request as WsRequest
 from websockets.http11 import Response
@@ -129,7 +131,11 @@ def handle_sessions_list(token: str, session_manager: Any, request: WsRequest) -
         return http_error(401, "Unauthorized")
     if session_manager is None:
         return http_error(503, "session manager unavailable")
-    sessions = session_manager.list_sessions()
+    try:
+        sessions = session_manager.list_sessions()
+    except Exception as exc:
+        logger.opt(exception=True).error("desktop_mate: list_sessions raised: {}", exc)
+        return http_error(500, "internal error")
     cleaned = [
         {k: v for k, v in s.items() if k != "path"}
         for s in sessions
@@ -150,7 +156,11 @@ def handle_session_messages(
         return http_error(400, "invalid session key")
     if not _is_dm_session(decoded):
         return http_error(404, "session not found")
-    data = session_manager.read_session_file(decoded)
+    try:
+        data = session_manager.read_session_file(decoded)
+    except Exception as exc:
+        logger.opt(exception=True).error("desktop_mate: read_session_file raised: {}", exc)
+        return http_error(500, "internal error")
     if data is None:
         return http_error(404, "session not found")
     return http_json_response(data)
@@ -168,7 +178,11 @@ def handle_session_delete(
         return http_error(400, "invalid session key")
     if not _is_dm_session(decoded):
         return http_error(404, "session not found")
-    deleted = session_manager.delete_session(decoded)
+    try:
+        deleted = session_manager.delete_session(decoded)
+    except Exception as exc:
+        logger.opt(exception=True).error("desktop_mate: delete_session raised: {}", exc)
+        return http_error(500, "internal error")
     return http_json_response({"deleted": bool(deleted)})
 
 

--- a/src/nanobot_runtime/channels/desktop_mate_rest.py
+++ b/src/nanobot_runtime/channels/desktop_mate_rest.py
@@ -25,6 +25,8 @@ from websockets.http11 import Request as WsRequest
 from websockets.http11 import Response
 
 
+SESSION_KEY_PREFIX = "desktop_mate:"
+
 # Session keys look like ``desktop_mate:<chat_id>``. Keep permissive enough
 # for hyphenated UUIDs and colon-separated namespacing, but tight enough
 # to rule out path traversal / quote injection.
@@ -50,7 +52,7 @@ def query_first(query: dict[str, list[str]], key: str) -> str | None:
 
 
 def bearer_token(headers: Any) -> str | None:
-    """Extract a ``Authorization: Bearer <token>`` header value."""
+    """Extract bearer token, accepting both ``Authorization`` and ``authorization`` headers."""
     auth = headers.get("Authorization") or headers.get("authorization")
     if auth and auth.lower().startswith("bearer "):
         return auth[7:].strip() or None
@@ -58,7 +60,6 @@ def bearer_token(headers: Any) -> str | None:
 
 
 def is_websocket_upgrade(request: WsRequest) -> bool:
-    """Return True iff the request is an actual WS upgrade handshake."""
     upgrade = request.headers.get("Upgrade") or request.headers.get("upgrade")
     connection = request.headers.get("Connection") or request.headers.get("connection")
     if not upgrade or "websocket" not in upgrade.lower():
@@ -69,7 +70,7 @@ def is_websocket_upgrade(request: WsRequest) -> bool:
 
 
 def decode_api_key(raw_key: str) -> str | None:
-    """URL-decode a session key from the path and validate it."""
+    """URL-decode and validate a session key from the path."""
     key = unquote(raw_key)
     if _API_KEY_RE.match(key) is None:
         return None
@@ -102,3 +103,89 @@ def http_json_response(data: dict[str, Any], *, status: int = 200) -> Response:
 def http_error(status: int, message: str | None = None) -> Response:
     body = (message or http.HTTPStatus(status).phrase).encode("utf-8")
     return http_response(body, status=status)
+
+
+# ---------------------------------------------------------------------------
+# Session REST handlers
+# ---------------------------------------------------------------------------
+
+
+def _is_dm_session(key: str) -> bool:
+    return key.startswith(SESSION_KEY_PREFIX)
+
+
+def _token_valid(token_cfg: str, request: WsRequest) -> bool:
+    """Check REST auth: Bearer header or ``?token=`` query param."""
+    expected = (token_cfg or "").strip()
+    if not expected:
+        return True
+    _, query = parse_request_path(request.path)
+    supplied = bearer_token(request.headers) or query_first(query, "token")
+    return supplied is not None and supplied == expected
+
+
+def handle_sessions_list(token: str, session_manager: Any, request: WsRequest) -> Response:
+    if not _token_valid(token, request):
+        return http_error(401, "Unauthorized")
+    if session_manager is None:
+        return http_error(503, "session manager unavailable")
+    sessions = session_manager.list_sessions()
+    cleaned = [
+        {k: v for k, v in s.items() if k != "path"}
+        for s in sessions
+        if isinstance(s.get("key"), str) and _is_dm_session(s["key"])
+    ]
+    return http_json_response({"sessions": cleaned})
+
+
+def handle_session_messages(
+    token: str, session_manager: Any, request: WsRequest, key: str
+) -> Response:
+    if not _token_valid(token, request):
+        return http_error(401, "Unauthorized")
+    if session_manager is None:
+        return http_error(503, "session manager unavailable")
+    decoded = decode_api_key(key)
+    if decoded is None:
+        return http_error(400, "invalid session key")
+    if not _is_dm_session(decoded):
+        return http_error(404, "session not found")
+    data = session_manager.read_session_file(decoded)
+    if data is None:
+        return http_error(404, "session not found")
+    return http_json_response(data)
+
+
+def handle_session_delete(
+    token: str, session_manager: Any, request: WsRequest, key: str
+) -> Response:
+    if not _token_valid(token, request):
+        return http_error(401, "Unauthorized")
+    if session_manager is None:
+        return http_error(503, "session manager unavailable")
+    decoded = decode_api_key(key)
+    if decoded is None:
+        return http_error(400, "invalid session key")
+    if not _is_dm_session(decoded):
+        return http_error(404, "session not found")
+    deleted = session_manager.delete_session(decoded)
+    return http_json_response({"deleted": bool(deleted)})
+
+
+def dispatch_http(
+    token: str, session_manager: Any, ws_path: str, request: WsRequest
+) -> Response | None:
+    """Route inbound HTTP to a REST handler; return None to proceed with WS upgrade."""
+    got, _ = parse_request_path(request.path)
+    if got == "/api/sessions":
+        return handle_sessions_list(token, session_manager, request)
+    m = re.match(r"^/api/sessions/([^/]+)/messages$", got)
+    if m:
+        return handle_session_messages(token, session_manager, request, m.group(1))
+    m = re.match(r"^/api/sessions/([^/]+)/delete$", got)
+    if m:
+        return handle_session_delete(token, session_manager, request, m.group(1))
+    expected_ws = ws_path.rstrip("/") or "/"
+    if got == expected_ws and is_websocket_upgrade(request):
+        return None
+    return http_error(404, "Not Found")

--- a/src/nanobot_runtime/channels/desktop_mate_server.py
+++ b/src/nanobot_runtime/channels/desktop_mate_server.py
@@ -1,0 +1,195 @@
+"""Server lifecycle and inbound loop mixin for DesktopMateChannel.
+
+``_DesktopMateServerMixin`` provides ``start``, ``stop``, and
+``_connection_loop``. Methods access state initialised in
+DesktopMateChannel.__init__: ``config``, ``_running``, ``_stop_event``,
+``_server``, ``_server_task``, ``_tts_enabled_per_chat``, and the methods
+``_handshake``, ``_dispatch_http``, ``_apply_connection_tts_override``,
+``_send_ready``, ``_decode_inbound_images``, ``_attach``, ``_send_frame``,
+``_detach_connection``, ``_handle_message``, and ``is_allowed``.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+
+from nanobot_runtime.channels.desktop_mate_protocol import (
+    ImageRejectedFrame,
+    MessageFrame,
+    NewChatFrame,
+    parse_inbound,
+)
+from nanobot_runtime.channels.desktop_mate_rest import parse_request_path, query_first
+
+
+class _DesktopMateServerMixin:
+    """WebSocket server lifecycle and inbound message loop."""
+
+    # -- Inbound loop ----------------------------------------------------------
+
+    async def _connection_loop(
+        self,
+        connection: Any,
+        *,
+        sender_id: str,
+        default_chat_id: str | None = None,
+    ) -> None:
+        """Consume inbound frames, dispatching ``new_chat`` / ``message``."""
+        async for raw in connection:
+            if isinstance(raw, bytes):
+                try:
+                    raw = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    logger.warning("desktop_mate: non-utf8 binary frame, ignored")
+                    continue
+
+            try:
+                envelope = parse_inbound(raw)
+            except (ValidationError, ValueError) as e:
+                logger.warning(
+                    "desktop_mate: bad inbound frame, ignored: {} ({!r})",
+                    e, raw[:100],
+                )
+                continue
+
+            base_metadata: dict[str, Any] = {
+                "tts_enabled": envelope.tts_enabled,
+                "reference_id": envelope.reference_id,
+                "remote": getattr(connection, "remote_address", None),
+            }
+
+            if isinstance(envelope, NewChatFrame):
+                chat_id = str(uuid.uuid4())
+            else:
+                assert isinstance(envelope, MessageFrame)
+                chat_id = envelope.chat_id
+
+            media_paths, reject_reason = self._decode_inbound_images(  # type: ignore[attr-defined]
+                envelope.images, sender_id=sender_id,
+            )
+            if reject_reason is not None:
+                # new_chat rejections have no chat_id yet; FE correlates via reference_id.
+                await self._send_frame(  # type: ignore[attr-defined]
+                    connection,
+                    ImageRejectedFrame(
+                        chat_id=chat_id if isinstance(envelope, MessageFrame) else None,
+                        reason=reject_reason,
+                        reference_id=envelope.reference_id,
+                    ),
+                )
+                continue
+
+            self._attach(chat_id, connection)  # type: ignore[attr-defined]
+            self._tts_enabled_per_chat[chat_id] = bool(envelope.tts_enabled)  # type: ignore[attr-defined]
+            # On any non-happy exit, unlink decoded image files to avoid disk
+            # leakage. Don't propagate the exception — the connection keeps serving.
+            try:
+                await self._handle_message(  # type: ignore[attr-defined]
+                    sender_id=sender_id,
+                    chat_id=chat_id,
+                    content=envelope.content,
+                    media=media_paths or None,
+                    metadata=base_metadata,
+                )
+            except Exception as exc:
+                logger.opt(exception=True).error(
+                    "desktop_mate: handle_message failed (chat_id={}): {}",
+                    chat_id, exc,
+                )
+                for p in media_paths:
+                    try:
+                        Path(p).unlink(missing_ok=True)
+                    except OSError as unlink_exc:
+                        logger.warning(
+                            "desktop_mate: leaked media {} (unlink after failure): {}",
+                            p, unlink_exc,
+                        )
+
+    # -- Server lifecycle ------------------------------------------------------
+
+    async def start(self) -> None:
+        """Bind the WS server and serve until :meth:`stop` is called."""
+        from websockets.asyncio.server import serve
+
+        self._running = True  # type: ignore[attr-defined]
+        self._stop_event = asyncio.Event()  # type: ignore[attr-defined]
+
+        async def handler(connection: Any) -> None:
+            request = getattr(connection, "request", None)
+            raw_path = request.path if request else "/"
+            _, query = parse_request_path(raw_path)
+
+            accepted = await self._handshake(connection, query)  # type: ignore[attr-defined]
+            if not accepted:
+                return
+
+            client_id = (query_first(query, "client_id") or "").strip()
+            if not client_id:
+                client_id = f"anon-{uuid.uuid4().hex[:12]}"
+            if not self.is_allowed(client_id):  # type: ignore[attr-defined]
+                try:
+                    await connection.close(code=4003, reason="forbidden")
+                except Exception:
+                    pass
+                return
+
+            self._apply_connection_tts_override(connection, query)  # type: ignore[attr-defined]
+            await self._send_ready(connection, client_id=client_id)  # type: ignore[attr-defined]
+
+            try:
+                await self._connection_loop(connection, sender_id=client_id)
+            except Exception as e:
+                logger.debug("desktop_mate: connection loop ended: {}", e)
+            finally:
+                self._detach_connection(connection)  # type: ignore[attr-defined]
+
+        config = self.config  # type: ignore[attr-defined]
+        logger.info(
+            "desktop_mate: listening on ws://{}:{}{}",
+            config.host, config.port, config.path,
+        )
+
+        async def runner() -> None:
+            async with serve(
+                handler,
+                config.host,
+                config.port,
+                process_request=self._dispatch_http,  # type: ignore[attr-defined]
+                ping_interval=config.ping_interval_s,
+                ping_timeout=config.ping_timeout_s,
+                max_size=config.max_message_bytes,
+            ) as server:
+                self._server = server  # type: ignore[attr-defined]
+                stop_event = self._stop_event  # type: ignore[attr-defined]
+                assert stop_event is not None
+                await stop_event.wait()
+
+        self._server_task = asyncio.create_task(runner())  # type: ignore[attr-defined]
+        try:
+            await self._server_task  # type: ignore[attr-defined]
+        except asyncio.CancelledError:
+            raise
+
+    async def stop(self) -> None:
+        if not self._running:  # type: ignore[attr-defined]
+            return
+        self._running = False  # type: ignore[attr-defined]
+        stop_event = self._stop_event  # type: ignore[attr-defined]
+        if stop_event is not None:
+            stop_event.set()
+        server_task = self._server_task  # type: ignore[attr-defined]
+        if server_task is not None:
+            try:
+                await asyncio.wait_for(server_task, timeout=2.0)
+            except (asyncio.TimeoutError, Exception) as e:
+                logger.debug("desktop_mate: server task cleanup: {}", e)
+                server_task.cancel()
+            self._server_task = None  # type: ignore[attr-defined]
+        self._chat_conn.clear()  # type: ignore[attr-defined]
+        self._streams.clear()  # type: ignore[attr-defined]
+        self._current_stream_id = None  # type: ignore[attr-defined]

--- a/src/nanobot_runtime/channels/desktop_mate_server.py
+++ b/src/nanobot_runtime/channels/desktop_mate_server.py
@@ -1,8 +1,8 @@
 """Server lifecycle and inbound loop mixin for DesktopMateChannel.
 
 ``_DesktopMateServerMixin`` provides ``start``, ``stop``, and
-``_connection_loop``. Methods access state initialised in
-DesktopMateChannel.__init__: ``config``, ``_running``, ``_stop_event``,
+``_connection_loop``. State from ``BaseChannel.__init__``: ``_running``.
+State from ``DesktopMateChannel.__init__``: ``config``, ``_stop_event``,
 ``_server``, ``_server_task``, ``_tts_enabled_per_chat``, and the methods
 ``_handshake``, ``_dispatch_http``, ``_apply_connection_tts_override``,
 ``_send_ready``, ``_decode_inbound_images``, ``_attach``, ``_send_frame``,
@@ -134,8 +134,8 @@ class _DesktopMateServerMixin:
             if not self.is_allowed(client_id):  # type: ignore[attr-defined]
                 try:
                     await connection.close(code=4003, reason="forbidden")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning("desktop_mate: close(4003/forbidden) raised: {}", e)
                 return
 
             self._apply_connection_tts_override(connection, query)  # type: ignore[attr-defined]
@@ -144,7 +144,10 @@ class _DesktopMateServerMixin:
             try:
                 await self._connection_loop(connection, sender_id=client_id)
             except Exception as e:
-                logger.debug("desktop_mate: connection loop ended: {}", e)
+                logger.opt(exception=True).warning(
+                    "desktop_mate: connection loop exited unexpectedly (client={}): {}",
+                    client_id, e,
+                )
             finally:
                 self._detach_connection(connection)  # type: ignore[attr-defined]
 
@@ -186,9 +189,11 @@ class _DesktopMateServerMixin:
         if server_task is not None:
             try:
                 await asyncio.wait_for(server_task, timeout=2.0)
-            except (asyncio.TimeoutError, Exception) as e:
-                logger.debug("desktop_mate: server task cleanup: {}", e)
+            except asyncio.TimeoutError:
+                logger.warning("desktop_mate: server task did not stop within 2s, cancelling")
                 server_task.cancel()
+            except Exception as e:
+                logger.warning("desktop_mate: server task ended with error during stop: {}", e)
             self._server_task = None  # type: ignore[attr-defined]
         self._chat_conn.clear()  # type: ignore[attr-defined]
         self._streams.clear()  # type: ignore[attr-defined]

--- a/src/nanobot_runtime/channels/desktop_mate_tts.py
+++ b/src/nanobot_runtime/channels/desktop_mate_tts.py
@@ -1,0 +1,94 @@
+"""TTS policy mixin for DesktopMateChannel.
+
+Provides per-chat/per-connection TTS enable/disable logic, the ``send_tts_chunk``
+TTSSink implementation, and emotion-emoji stripping for delta text.
+
+Methods access state initialised in DesktopMateChannel.__init__:
+``_tts_enabled_per_chat``, ``_tts_enabled_per_conn``, ``_current_stream_id``,
+``_streams``, ``_chat_conn``, ``_emotion_strip_re``, and ``_send_frame``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from nanobot_runtime.channels.desktop_mate_config import _parse_bool_flag
+from nanobot_runtime.channels.desktop_mate_protocol import TTSChunkFrame
+from nanobot_runtime.channels.desktop_mate_rest import query_first
+from nanobot_runtime.hooks.tts import TTSChunk
+
+
+class _DesktopMateTTSMixin:
+    """TTS policy and sink methods — mixed into DesktopMateChannel."""
+
+    def _strip_emotions(self, text: str) -> str:
+        pattern = self._emotion_strip_re  # type: ignore[attr-defined]
+        if pattern is None:
+            return text
+        return pattern.sub("", text)
+
+    def _apply_connection_tts_override(
+        self, connection: Any, query: dict[str, list[str]]
+    ) -> None:
+        """Read the URL ``tts`` param during handshake and record per-connection policy."""
+        flag = _parse_bool_flag(query_first(query, "tts"))
+        if flag is None:
+            return
+        self._tts_enabled_per_conn[id(connection)] = flag  # type: ignore[attr-defined]
+
+    def _tts_enabled_for_chat(self, chat_id: str) -> bool:
+        """Effective policy: connection override wins over per-chat flag; default True."""
+        conn = self._chat_conn.get(chat_id)  # type: ignore[attr-defined]
+        if conn is not None:
+            conn_flag = self._tts_enabled_per_conn.get(id(conn))  # type: ignore[attr-defined]
+            if conn_flag is not None:
+                return conn_flag
+        return self._tts_enabled_per_chat.get(chat_id, True)  # type: ignore[attr-defined]
+
+    def is_tts_enabled_for_current_stream(self) -> bool:
+        """Return False when no desktop_mate stream is currently registered.
+
+        This prevents TTSHook from synthesising for turns running on other
+        channels (e.g. the idle-watcher firing through ``channel=cli``).
+        """
+        stream_id = self._current_stream_id  # type: ignore[attr-defined]
+        if stream_id is None:
+            return False
+        info = self._streams.get(stream_id)  # type: ignore[attr-defined]
+        if info is None:
+            return False
+        chat_id, _ = info
+        return self._tts_enabled_for_chat(chat_id)
+
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
+        """Emit a ``tts_chunk`` frame for the currently streaming chat."""
+        stream_id = self._current_stream_id  # type: ignore[attr-defined]
+        if stream_id is None or stream_id not in self._streams:  # type: ignore[attr-defined]
+            logger.warning(
+                "desktop_mate: send_tts_chunk with no active stream (seq={}); dropping",
+                chunk.sequence,
+            )
+            return
+        chat_id, proactive = self._streams[stream_id]  # type: ignore[attr-defined]
+        conn = self._chat_conn.get(chat_id)  # type: ignore[attr-defined]
+        if conn is None:
+            logger.warning("desktop_mate: tts_chunk target gone (chat_id={})", chat_id)
+            return
+
+        # MVP trade-off: synthesis still ran upstream (see migration-todo §3-C.α).
+        if not self._tts_enabled_for_chat(chat_id):
+            return
+
+        await self._send_frame(  # type: ignore[attr-defined]
+            conn,
+            TTSChunkFrame(
+                chat_id=chat_id,
+                sequence=chunk.sequence,
+                text=chunk.text,
+                audio_base64=chunk.audio_base64,
+                emotion=chunk.emotion,
+                keyframes=list(chunk.keyframes),
+                proactive=True if proactive else None,
+            ),
+        )

--- a/src/nanobot_runtime/hooks/tts.py
+++ b/src/nanobot_runtime/hooks/tts.py
@@ -207,15 +207,17 @@ class TTSHook(AgentHook):
             self._states[key] = state
         return state
 
+    def _sink_is_enabled(self) -> bool:
+        fn = getattr(self._sink, "is_enabled", None)
+        return not callable(fn) or fn()
+
     def _dispatch_sentence(self, state: _SessionState, sentence: str) -> None:
         text, emotion = self._preprocessor.process(sentence)
         if not text or not any(ch.isalnum() for ch in text):
             return
-        # Honour the sink's opt-in TTS-off signal. Sinks without this method
-        # (e.g. older test fakes) are treated as always-enabled. We drop the
-        # sentence silently — no task created, no synthesis, no sequence bump.
-        is_enabled = getattr(self._sink, "is_enabled", None)
-        if callable(is_enabled) and not is_enabled():
+        # Sinks without is_enabled() are treated as always-enabled.
+        # We drop silently — no task, no synthesis, no sequence bump.
+        if not self._sink_is_enabled():
             return
         sequence = state.sequence
         state.sequence += 1
@@ -225,14 +227,10 @@ class TTSHook(AgentHook):
     async def _synth_and_emit(
         self, text: str, emotion: str | None, sequence: int
     ) -> None:
-        # Second-chance check: _dispatch_sentence already gated, but the
-        # sink's enabled state can change between "task scheduled" and
-        # "task running" — for instance when the channel hasn't yet
-        # registered the stream at dispatch time, then learns it's off.
-        # Re-checking here ensures we never call synthesize() for a
-        # stream that's known-disabled by the time we'd do the work.
-        is_enabled = getattr(self._sink, "is_enabled", None)
-        if callable(is_enabled) and not is_enabled():
+        # Second-chance check: sink's enabled state can change between task
+        # scheduled and task running (e.g. channel registers the stream as
+        # off after dispatch). Re-checking avoids a wasted synthesize() call.
+        if not self._sink_is_enabled():
             return
         try:
             audio_b64 = await self._synthesizer.synthesize(text)

--- a/src/nanobot_runtime/proactive/idle.py
+++ b/src/nanobot_runtime/proactive/idle.py
@@ -161,7 +161,12 @@ class IdleScanner:
 
     def _is_in_cooldown(self, key: str, now: datetime) -> bool:
         until = self._cooldown_until.get(key)
-        return until is not None and now.timestamp() < until
+        if until is None:
+            return False
+        if now.timestamp() >= until:
+            del self._cooldown_until[key]
+            return False
+        return True
 
 
 def install_idle_system_job(

--- a/src/nanobot_runtime/tts/chunker.py
+++ b/src/nanobot_runtime/tts/chunker.py
@@ -66,7 +66,7 @@ class SentenceChunker:
         self._buffer = self._tool_call_pattern.sub("", self._buffer)
 
         result: list[str] = []
-        while any(c in self._SENTENCE_ENDERS for c in self._buffer):
+        while True:
             positions = self._fb.find_eos(self._buffer)
             real_positions = [
                 p
@@ -107,7 +107,7 @@ class SentenceChunker:
 
     def _filter_reasoning_stream(self, chunk: str) -> str:
         parts = self._reasoning_pattern.split(chunk)
-        filtered = ""
+        out: list[str] = []
         for part in parts:
             if not part:
                 continue
@@ -117,8 +117,8 @@ class SentenceChunker:
             elif lowered == "</think>":
                 self._inside_reasoning = False
             elif not self._inside_reasoning:
-                filtered += part
-        return filtered
+                out.append(part)
+        return "".join(out)
 
     def _reset(self) -> None:
         self._buffer = ""

--- a/tests/channels/test_desktop_mate.py
+++ b/tests/channels/test_desktop_mate.py
@@ -468,8 +468,8 @@ def test_desktop_mate_config_defaults_keepalive_and_max_size():
     cfg = DesktopMateConfig()
     assert cfg.ping_interval_s == 20.0
     assert cfg.ping_timeout_s == 20.0
-    # 6 MB covers DMP image-in-base64 upper bound.
-    assert cfg.max_message_bytes == 6 * 1024 * 1024
+    # 60 MB: _MAX_IMAGES_PER_MESSAGE (4) × 10 MB base64-encoded (×4/3) ≈ 53 MB.
+    assert cfg.max_message_bytes == 60 * 1024 * 1024
 
 
 # ---------------------------------------------------------------------------
@@ -759,4 +759,4 @@ async def test_start_passes_ping_and_max_size_to_serve(monkeypatch):
     kwargs = captured.get("kwargs") or {}
     assert kwargs.get("ping_interval") == 20.0
     assert kwargs.get("ping_timeout") == 20.0
-    assert kwargs.get("max_size") == 6 * 1024 * 1024
+    assert kwargs.get("max_size") == 60 * 1024 * 1024

--- a/tests/channels/test_desktop_mate_images.py
+++ b/tests/channels/test_desktop_mate_images.py
@@ -410,7 +410,7 @@ async def test_io_error_during_persist_surfaces_as_io_error(
         raise OSError("disk write failed (simulated)")
 
     monkeypatch.setattr(
-        "nanobot_runtime.channels.desktop_mate.save_base64_data_url",
+        "nanobot_runtime.channels.desktop_mate_image.save_base64_data_url",
         _raise_oserror,
     )
     conn = FakeConnection(inbox=[

--- a/tests/proactive/test_idle.py
+++ b/tests/proactive/test_idle.py
@@ -319,6 +319,32 @@ async def test_install_disabled_config_is_noop() -> None:
     assert cron.on_job is sentinel  # untouched
 
 
+def test_is_in_cooldown_evicts_expired_entry() -> None:
+    """_is_in_cooldown must remove expired entries from _cooldown_until.
+
+    Regression: the method changed from a pure read to a read-with-eviction.
+    Removing the ``del`` would silently pass higher-level cooldown tests while
+    allowing stale keys to accumulate in long-running processes.
+    """
+    now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
+    scanner = IdleScanner(
+        agent=_build_agent(),
+        sessions=_build_sessions([]),
+        config=_cfg(cooldown_s=900),
+        clock=lambda: now,
+    )
+    key = "desktop_mate:abc"
+    # Plant an already-expired cooldown entry (expired 1 second ago).
+    scanner._cooldown_until[key] = now.timestamp() - 1
+
+    # First call: expired → must return False and remove the key.
+    assert scanner._is_in_cooldown(key, now) is False
+    assert key not in scanner._cooldown_until
+
+    # Second call: key is gone → must still return False (not KeyError).
+    assert scanner._is_in_cooldown(key, now) is False
+
+
 async def test_install_idle_job_invokes_scanner() -> None:
     """When composite receives the idle job id, it must trigger scan_and_nudge."""
     now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)

--- a/tests/tts/test_chunker.py
+++ b/tests/tts/test_chunker.py
@@ -79,3 +79,18 @@ def test_default_min_chunk_length_is_50() -> None:
     c = SentenceChunker()
     # A 10-char sentence should NOT emit at default min_chunk_length=50.
     assert c.feed("Hello.") == []
+
+
+def test_while_true_loop_breaks_when_no_real_position_found() -> None:
+    # Regression: the while True loop must break and not spin when find_eos
+    # returns positions that all fail the _SENTENCE_ENDERS filter. A buffer
+    # ending with whitespace after a letter is a natural case where the EOS
+    # detector may report a position but the stripped prefix does not end with
+    # a sentence-ender character, so real_positions ends up empty.
+    c = SentenceChunker(min_chunk_length=0)
+    # Feed text with no sentence-ending character — loop must exit without
+    # hanging and leave the text in the buffer for flush().
+    result = c.feed("No terminator, just a trailing space ")
+    assert result == []
+    remainder = c.flush()
+    assert remainder is not None and "No terminator" in remainder


### PR DESCRIPTION
## Summary

- **Commit 1** — Small efficiency/quality improvements across `tts`, `chunker`, `idle`
- **Commit 2** — Move session REST handlers out of `DesktopMateChannel` into `desktop_mate_rest.py` as standalone functions
- **Commit 3** — Split `desktop_mate.py` (966 lines) into four focused modules, reducing the main file to 304 lines

### New file layout (`channels/`)

| File | Lines | Responsibility |
|---|---|---|
| `desktop_mate_config.py` | 79 | `DesktopMateConfig` dataclass, coercion, `_parse_bool_flag` |
| `desktop_mate_image.py` | 111 | Image decode / MIME / size validation (`_decode_images`) |
| `desktop_mate_tts.py` | 94 | `_DesktopMateTTSMixin`: TTS policy + `send_tts_chunk` + `_strip_emotions` |
| `desktop_mate_server.py` | 195 | `_DesktopMateServerMixin`: `start`, `stop`, `_connection_loop` |
| `desktop_mate_rest.py` | 191 | HTTP helpers + session REST handlers + `dispatch_http` |
| **`desktop_mate.py`** | **304** | Core: init, bookkeeping, `send`/`send_delta`, auth |

### Other fixes in commit 3

- Replace `_load_emotion_emojis_from_yaml` with `EmotionMapper.from_yaml().known_emojis` (removes duplicate YAML reader — the old docstring itself flagged this as "shared source of truth")
- `_strip_emotions`: compile regex once at `__init__` instead of k `str.replace` calls per delta (hot path)
- `handler()` in `start()`: consolidate all query-param extraction to `query_first`; remove redundant `urlparse`/`parse_qs` inline
- Fix test assertion: `max_message_bytes` default is 60 MB (needed for 4 × 10 MB images base64-encoded ≈ 53 MB), not 6 MB

## Test plan

- [x] All 188 unit tests pass (`pytest tests/` excluding e2e/regression)
- [x] `test_desktop_mate_rest.py` — REST routing, auth, session CRUD all exercised
- [x] `test_desktop_mate_images.py` — monkeypatch target updated to new module path
- [x] `test_gateway_sm_injection.py` — session_manager injection via ChannelManager patch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)