### PR TITLE
fix(proactive): single-target dispatch via bus + startup grace

### DIFF
--- a/src/nanobot_runtime/channels/desktop_mate.py
+++ b/src/nanobot_runtime/channels/desktop_mate.py
@@ -108,6 +108,11 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         # synthesis still runs. See migration-todo §3-C.α).
         # chat_id -> bool; absent == True (default enabled).
         self._tts_enabled_per_chat: dict[str, bool] = {}
+        # chat_id -> reference_id (voice id) most recently sent by the FE.
+        # Survives across turns within a session so proactive nudges (which
+        # carry no envelope) can reuse the user's chosen voice. ``None``
+        # means "use the synthesizer's default".
+        self._reference_id_per_chat: dict[str, str | None] = {}
         # connection id() -> bool; takes precedence over per-chat flags
         # so URL ``?tts=0`` overrides per-message toggles for the whole socket.
         self._tts_enabled_per_conn: dict[int, bool] = {}
@@ -129,6 +134,7 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
             if conn is connection:
                 self._chat_conn.pop(cid, None)
                 self._tts_enabled_per_chat.pop(cid, None)
+                self._reference_id_per_chat.pop(cid, None)
         self._tts_enabled_per_conn.pop(id(connection), None)
         for sid, (cid, _) in list(self._streams.items()):
             if cid not in self._chat_conn:
@@ -292,3 +298,22 @@ class LazyChannelTTSSink:
         except RuntimeError:
             return
         await channel.send_tts_chunk(chunk)
+
+    def get_reference_id_for_session(self, session_key: str | None) -> str | None:
+        """Resolve the voice for ``session_key`` via the active channel.
+
+        ``session_key`` follows the nanobot ``"<channel>:<chat_id>"`` form. Only
+        ``desktop_mate:*`` keys can be resolved here; anything else (or a
+        missing channel) returns ``None`` so the synthesizer falls back to its
+        constructor default.
+        """
+        if not session_key:
+            return None
+        prefix, _, chat_id = session_key.partition(":")
+        if prefix != "desktop_mate" or not chat_id:
+            return None
+        try:
+            channel = get_desktop_mate_channel()
+        except RuntimeError:
+            return None
+        return channel.reference_id_for_chat_id(chat_id)

--- a/src/nanobot_runtime/channels/desktop_mate_server.py
+++ b/src/nanobot_runtime/channels/desktop_mate_server.py
@@ -84,6 +84,10 @@ class _DesktopMateServerMixin:
 
             self._attach(chat_id, connection)  # type: ignore[attr-defined]
             self._tts_enabled_per_chat[chat_id] = bool(envelope.tts_enabled)  # type: ignore[attr-defined]
+            # Cache the FE-chosen voice for the lifetime of this chat. Used by
+            # TTSHook (via the LazyChannelTTSSink resolver) so proactive turns
+            # — which carry no envelope — still hit the same voice.
+            self._reference_id_per_chat[chat_id] = envelope.reference_id  # type: ignore[attr-defined]
             # On any non-happy exit, unlink decoded image files to avoid disk
             # leakage. Don't propagate the exception — the connection keeps serving.
             try:

--- a/src/nanobot_runtime/channels/desktop_mate_tts.py
+++ b/src/nanobot_runtime/channels/desktop_mate_tts.py
@@ -44,6 +44,15 @@ class _DesktopMateTTSMixin:
                 return conn_flag
         return self._tts_enabled_per_chat.get(chat_id, True)  # type: ignore[attr-defined]
 
+    def reference_id_for_chat_id(self, chat_id: str) -> str | None:
+        """Return the FE-supplied voice for ``chat_id``, or None if unknown.
+
+        Populated by the inbound server loop on every ``new_chat`` / ``message``
+        envelope, so a session that has ever been touched keeps its voice for
+        subsequent turns — including proactive nudges that bypass the FE.
+        """
+        return self._reference_id_per_chat.get(chat_id)  # type: ignore[attr-defined]
+
     def is_tts_enabled_for_current_stream(self) -> bool:
         """Return False when no desktop_mate stream is currently registered.
 

--- a/src/nanobot_runtime/gateway.py
+++ b/src/nanobot_runtime/gateway.py
@@ -6,8 +6,16 @@ pre-imports ``nanobot.agent.loop.AgentLoop`` and monkey-patches its
 dispatches to nanobot's Typer CLI with the ``gateway`` subcommand so the
 patch applies in-process to the AgentLoop constructed by the CLI.
 
+Also patches ``AgentLoop.run`` to spawn a stashed idle-watcher coroutine
+once the event loop is live. ``hooks_factory`` cannot do this directly:
+it executes inside ``AgentLoop.__init__``, before nanobot's CLI has
+finished wiring (in particular, before ``cli/commands.py`` reassigns
+``cron.on_job``), and outside any running event loop. By deferring the
+spawn to ``run``, we guarantee both a live loop and a fully-wired agent.
+
 Pinned to nanobot 0.1.5.x — version drift fails loud at startup.
 """
+import asyncio
 import inspect
 import os
 from typing import Any, Callable
@@ -17,6 +25,8 @@ from loguru import logger
 from nanobot.agent.hook import AgentHook
 from nanobot.agent.loop import AgentLoop
 from nanobot.channels.manager import ChannelManager
+
+from nanobot_runtime.proactive.idle import IDLE_ASYNCIO_TASK_ATTR
 
 _SUPPORTED_PREFIXES = ("0.1.5",)
 
@@ -44,6 +54,35 @@ def _install_monkey_patch(hooks_factory: HooksFactory) -> None:
         )
 
     AgentLoop.__init__ = _patched_init  # type: ignore[assignment]
+
+
+def _install_run_patch() -> None:
+    """Wrap ``AgentLoop.run`` to spawn a stashed idle-watcher task once.
+
+    The watcher coroutine factory is set by
+    :func:`nanobot_runtime.proactive.idle.install_idle_asyncio_task` during
+    ``hooks_factory``. We can't ``asyncio.create_task`` it from there
+    because ``__init__`` runs synchronously before the event loop is up.
+    By the time ``run`` is awaited, ``cli/commands.py`` has finished
+    reassigning ``cron.on_job`` and the event loop is live — both
+    preconditions for a working scanner.
+
+    Idempotent via ``_yuri_idle_task_started`` so a hypothetical double-run
+    cannot stack two scanners on the same agent. The spawned task is also
+    stored on the agent so callers (tests, ``/stop`` shutdown) can cancel it.
+    """
+    _orig_run = AgentLoop.run
+
+    async def _patched_run(self: AgentLoop, *args: Any, **kwargs: Any) -> Any:
+        starter = getattr(self, IDLE_ASYNCIO_TASK_ATTR, None)
+        if starter is not None and not getattr(self, "_yuri_idle_task_started", False):
+            self._yuri_idle_task_started = True  # type: ignore[attr-defined]
+            task = asyncio.create_task(starter(), name="yuri-idle-watcher")
+            self._yuri_idle_task = task  # type: ignore[attr-defined]
+            logger.info("nanobot_runtime: idle watcher task spawned")
+        return await _orig_run(self, *args, **kwargs)
+
+    AgentLoop.run = _patched_run  # type: ignore[assignment]
 
 
 def _install_channel_manager_patch() -> None:
@@ -119,6 +158,7 @@ def run(
     ``NANOBOT_WORKSPACE`` env vars, then to ``./nanobot.json`` / ``.``.
     """
     _install_monkey_patch(hooks_factory)
+    _install_run_patch()
     _install_channel_manager_patch()
 
     # Import after patch so any import-time side effects see the patched class.

--- a/src/nanobot_runtime/hooks/tts.py
+++ b/src/nanobot_runtime/hooks/tts.py
@@ -74,8 +74,20 @@ class EmotionMapper(Protocol):
 
 
 class TTSSynthesizer(Protocol):
-    async def synthesize(self, text: str) -> str | None:
-        """Return base64-encoded audio (wav) or None on failure."""
+    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
+        """Return base64-encoded audio (wav) or None on failure.
+
+        ``reference_id`` is an optional per-call voice override. ``None``
+        means "use the synthesizer's default"; an empty string forces no
+        reference even when the synthesizer has a baked-in default.
+        """
+
+
+# Resolves a session_key (``"desktop_mate:<chat_id>"``-style) to the voice
+# to use for that session, or ``None`` to fall back to the synthesizer's
+# default. The hook calls this *once per sentence dispatch*, so the resolver
+# may consult mutable channel state without stale-cache concerns.
+ReferenceIdResolver = Callable[[str | None], str | None]
 
 
 class TTSSink(Protocol):
@@ -96,6 +108,9 @@ class _SessionState:
     chunker: SentenceChunker
     sequence: int = 0
     pending: list[asyncio.Task[None]] = field(default_factory=list)
+    # Cached so ``_dispatch_sentence`` can call the resolver without
+    # threading the AgentHookContext through every helper.
+    session_key: str | None = None
 
 
 _FALLBACK_SESSION_KEY = "__tts_hook_default__"
@@ -114,6 +129,7 @@ class TTSHook(AgentHook):
         synthesizer: TTSSynthesizer,
         sink: TTSSink,
         barrier_timeout_seconds: float = 30.0,
+        reference_id_resolver: ReferenceIdResolver | None = None,
     ) -> None:
         super().__init__()
         self._chunker_factory = chunker_factory
@@ -122,6 +138,7 @@ class TTSHook(AgentHook):
         self._synthesizer = synthesizer
         self._sink = sink
         self._barrier_timeout = barrier_timeout_seconds
+        self._reference_id_resolver = reference_id_resolver
         self._states: dict[str, _SessionState] = {}
         self._fallback_warned = False
 
@@ -197,9 +214,20 @@ class TTSHook(AgentHook):
         key = self._session_key(context)
         state = self._states.get(key)
         if state is None:
-            state = _SessionState(chunker=self._chunker_factory())
+            state = _SessionState(chunker=self._chunker_factory(), session_key=key)
             self._states[key] = state
         return state
+
+    def _resolve_reference_id(self, session_key: str | None) -> str | None:
+        if self._reference_id_resolver is None:
+            return None
+        try:
+            return self._reference_id_resolver(session_key)
+        except Exception:
+            # Resolver failure must not block synthesis — fall back to the
+            # synthesizer's constructor default.
+            logger.exception("TTSHook reference_id resolver raised (session={})", session_key)
+            return None
 
     def _sink_is_enabled(self) -> bool:
         fn = getattr(self._sink, "is_enabled", None)
@@ -213,13 +241,24 @@ class TTSHook(AgentHook):
         # We drop silently — no task, no synthesis, no sequence bump.
         if not self._sink_is_enabled():
             return
+        # Resolve voice up-front so a per-tick state change in the channel
+        # (e.g. user re-sends with a different reference_id mid-stream) does
+        # not split the same sentence across two voices.
+        reference_id = self._resolve_reference_id(state.session_key)
         sequence = state.sequence
         state.sequence += 1
-        task = asyncio.create_task(self._synth_and_emit(text, emotion, sequence))
+        task = asyncio.create_task(
+            self._synth_and_emit(text, emotion, sequence, reference_id=reference_id)
+        )
         state.pending.append(task)
 
     async def _synth_and_emit(
-        self, text: str, emotion: str | None, sequence: int
+        self,
+        text: str,
+        emotion: str | None,
+        sequence: int,
+        *,
+        reference_id: str | None = None,
     ) -> None:
         # Second-chance check: sink's enabled state can change between task
         # scheduled and task running (e.g. channel registers the stream as
@@ -227,7 +266,7 @@ class TTSHook(AgentHook):
         if not self._sink_is_enabled():
             return
         try:
-            audio_b64 = await self._synthesizer.synthesize(text)
+            audio_b64 = await self._synthesizer.synthesize(text, reference_id=reference_id)
         except Exception:
             logger.exception("TTS synth failed (seq={})", sequence)
             audio_b64 = None

--- a/src/nanobot_runtime/proactive/__init__.py
+++ b/src/nanobot_runtime/proactive/__init__.py
@@ -4,9 +4,11 @@ Currently exposes the Phase 5-A Idle Watcher. Schedule/Cron is handled by
 nanobot-native ``CronService`` with no extra glue on our side.
 """
 from nanobot_runtime.proactive.idle import (
+    IDLE_ASYNCIO_TASK_ATTR,
     IDLE_SYSTEM_JOB_ID,
     IdleConfig,
     IdleScanner,
     QuietHours,
+    install_idle_asyncio_task,
     install_idle_system_job,
 )

--- a/src/nanobot_runtime/proactive/idle.py
+++ b/src/nanobot_runtime/proactive/idle.py
@@ -4,11 +4,23 @@ Phase 5 Proactive (A) — wakes the agent on a user's channel when a session
 has been silent past ``idle_timeout_s``. Schedule, session iteration and
 outbound delivery all ride nanobot-native primitives; the only logic we
 own is the judgment gate (quiet hours, channel allowlist, idle threshold,
-active-turn, cooldown, re-validation race).
+active-turn, cooldown, re-validation race) plus single-target selection.
+
+Selection model: at most one nudge per scan tick, sent to the most-recently
+updated allowlisted session. Conversation history does not cross channels
+(``unifiedSession=false``), so a "most recent" target is well-defined per
+allowlist scope. See issue #19 for the cross-channel design space.
+
+Dispatch path: scanner publishes a synthesized ``InboundMessage`` with
+``_wants_stream=True`` and ``proactive=True`` metadata. The nanobot
+``AgentLoop._dispatch`` consumer picks it up, wires the streaming hooks
+(deltas + stream_end), runs the agent loop, and publishes the final
+OutboundMessage — identical to a real user message, so DesktopMateChannel
+streaming and TTS chunk routing work without proactive-specific glue.
 
 Installed via :func:`install_idle_system_job` from the gateway launcher.
 """
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Awaitable, Callable, Protocol
 from zoneinfo import ZoneInfo
 
@@ -16,9 +28,11 @@ from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field
 
 try:
+    from nanobot.bus.events import InboundMessage
     from nanobot.cron.types import CronJob, CronPayload, CronSchedule
 except ImportError:  # pragma: no cover - allows isolated static analysis
     CronJob = CronPayload = CronSchedule = None  # type: ignore[assignment]
+    InboundMessage = None  # type: ignore[assignment]
 
 
 IDLE_SYSTEM_JOB_ID = "idle-watcher"
@@ -54,6 +68,13 @@ class IdleConfig(BaseModel):
     idle_timeout_s: int = Field(default=300, description="Seconds of silence before a nudge is sent.")
     cooldown_s: int = Field(default=900, description="Minimum seconds between nudges for the same session.")
     scan_interval_s: int = Field(default=30, description="How often the watcher scans sessions (seconds).")
+    startup_grace_s: int = Field(
+        default=120,
+        ge=0,
+        description="Seconds after process start during which all nudges are suppressed. "
+        "Prevents the reboot-storm where dormant sessions trigger bulk nudges before "
+        "the in-memory cooldown table has been populated.",
+    )
     quiet_hours: "QuietHours | None" = Field(default=None, description="Time window during which nudges are suppressed.")
     timezone: str = Field(default="UTC", description="IANA timezone name for quiet-hours evaluation.")
     channels: tuple[str, ...] = Field(default=("desktop_mate",), description="Channel names that receive idle nudges.")
@@ -71,14 +92,7 @@ class _SessionManagerLike(Protocol):
 
 class _AgentLike(Protocol):
     _session_locks: dict[str, Any]
-
-    async def process_direct(
-        self,
-        content: str,
-        session_key: str = ...,
-        channel: str = ...,
-        chat_id: str = ...,
-    ) -> Any: ...
+    bus: Any  # nanobot.bus.queue.MessageBus — typed loosely so this module imports without nanobot.
 
 
 class _CronLike(Protocol):
@@ -104,12 +118,44 @@ class IdleScanner:
         self._tz = ZoneInfo(config.timezone)
         self._clock = clock or (lambda: datetime.now(tz=self._tz))
         self._cooldown_until: dict[str, float] = {}
+        self._started_at: datetime = self._clock()
 
     async def scan_and_nudge(self) -> None:
         now = self._clock()
+        if (now - self._started_at).total_seconds() < self._config.startup_grace_s:
+            return
         if self._config.quiet_hours and _in_quiet_hours(now, self._config.quiet_hours):
             return
 
+        target = self._select_target(now)
+        if target is None:
+            return
+
+        key, channel, chat_id, fresh_updated = target
+
+        # Mark cooldown BEFORE dispatch so a downstream failure cannot drive a retry storm.
+        self._cooldown_until[key] = now.timestamp() + self._config.cooldown_s
+
+        minutes = _minutes_between(fresh_updated, now)
+        prompt = self._config.idle_prompt.format(minutes=minutes)
+        try:
+            await self._dispatch_nudge(key=key, channel=channel, chat_id=chat_id, prompt=prompt)
+            logger.info("Idle nudge dispatched: session={} idle={}m", key, minutes)
+        except Exception:
+            logger.exception("Idle nudge failed for {}", key)
+
+    def _select_target(
+        self, now: datetime
+    ) -> tuple[str, str, str, datetime] | None:
+        """Pick the most-recently-updated allowlisted session that passes every gate.
+
+        Returns ``(session_key, channel, chat_id, fresh_updated_at)`` or ``None``.
+
+        Selection — single target per tick — embodies issue #19's per-channel
+        isolation (no cross-channel "user is active somewhere" notion) and the
+        Phase 5-A spec of "one nudge per scan tick at most".
+        """
+        best: tuple[str, str, str, datetime] | None = None
         for info in self._sessions.list_sessions():
             key = info.get("key") or ""
             if ":" not in key:
@@ -130,22 +176,38 @@ class IdleScanner:
             fresh_updated = getattr(fresh, "updated_at", None)
             if not self._is_idle(fresh_updated, now):
                 continue
-
-            # Mark cooldown BEFORE dispatch so exceptions don't cause retry storms.
-            self._cooldown_until[key] = now.timestamp() + self._config.cooldown_s
-
-            minutes = _minutes_between(fresh_updated, now)
-            prompt = self._config.idle_prompt.format(minutes=minutes)
             try:
-                await self._agent.process_direct(
-                    prompt,
-                    session_key=key,
-                    channel=channel,
-                    chat_id=chat_id,
-                )
-                logger.info("Idle nudge delivered: session={} idle={}m", key, minutes)
-            except Exception:
-                logger.exception("Idle nudge failed for {}", key)
+                fresh_dt = _to_aware(fresh_updated, self._tz)
+            except (TypeError, ValueError):
+                continue
+
+            if best is None or fresh_dt > best[3]:
+                best = (key, channel, chat_id, fresh_dt)
+        return best
+
+    async def _dispatch_nudge(
+        self, *, key: str, channel: str, chat_id: str, prompt: str
+    ) -> None:
+        """Publish a synthesized inbound message that rides the normal _dispatch path.
+
+        ``_wants_stream`` enables the streaming callback wiring inside
+        ``AgentLoop._dispatch`` (deltas + stream_end OutboundMessages on the bus),
+        which is what registers ``_current_stream_id`` on DesktopMateChannel and
+        makes TTS chunk routing work end-to-end.
+        """
+        if InboundMessage is None:  # pragma: no cover - import-time guard
+            raise RuntimeError(
+                "nanobot.bus.events unavailable — IdleScanner requires nanobot-ai runtime"
+            )
+        msg = InboundMessage(
+            channel=channel,
+            sender_id="idle-watcher",
+            chat_id=chat_id,
+            content=prompt,
+            metadata={"proactive": True, "_wants_stream": True},
+            session_key_override=key,
+        )
+        await self._agent.bus.publish_inbound(msg)
 
     def _is_active_turn(self, key: str) -> bool:
         locks = getattr(self._agent, "_session_locks", None)

--- a/src/nanobot_runtime/proactive/idle.py
+++ b/src/nanobot_runtime/proactive/idle.py
@@ -20,6 +20,7 @@ streaming and TTS chunk routing work without proactive-specific glue.
 
 Installed via :func:`install_idle_system_job` from the gateway launcher.
 """
+import asyncio
 from datetime import datetime
 from typing import Any, Awaitable, Callable, Protocol
 from zoneinfo import ZoneInfo
@@ -36,6 +37,7 @@ except ImportError:  # pragma: no cover - allows isolated static analysis
 
 
 IDLE_SYSTEM_JOB_ID = "idle-watcher"
+IDLE_ASYNCIO_TASK_ATTR = "_yuri_idle_scanner_starter"
 
 _DEFAULT_IDLE_PROMPT = (
     "[Idle Nudge] The user has been silent for {minutes} minutes. "
@@ -292,6 +294,63 @@ def install_idle_system_job(
         config.scan_interval_s,
         list(config.channels),
     )
+    return scanner
+
+
+def install_idle_asyncio_task(
+    *,
+    agent: Any,
+    sessions: _SessionManagerLike,
+    config: IdleConfig,
+    clock: Callable[[], datetime] | None = None,
+) -> IdleScanner | None:
+    """Install the idle watcher as a free-standing asyncio task on ``agent``.
+
+    Why: nanobot's ``cli/commands.py`` reassigns ``cron.on_job`` *after*
+    ``AgentLoop.__init__`` returns, which silently overwrites the composite
+    that :func:`install_idle_system_job` installs during ``hooks_factory``.
+    The cron path therefore never reaches ``scan_and_nudge`` in a real
+    gateway boot. This installer sidesteps cron entirely: the gateway
+    monkey-patch wraps ``AgentLoop.run`` and starts the stashed coroutine
+    once the event loop is live, so the watcher runs on its own ``asyncio``
+    timer with no third-party touch points.
+
+    Returns the scanner (so tests/manual triggers still work) or ``None``
+    when ``config.enabled`` is False.
+
+    Side effect: sets ``agent`` attribute :data:`IDLE_ASYNCIO_TASK_ATTR` to
+    a zero-arg coroutine factory. The gateway patch spawns it exactly once;
+    if no patch is installed, the watcher is silently inert (matches the
+    "disabled" contract).
+    """
+    if not config.enabled:
+        return None
+
+    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=clock)
+
+    async def _scanner_loop() -> None:
+        logger.info(
+            "Idle watcher started (timeout={}s cooldown={}s scan={}s channels={})",
+            config.idle_timeout_s,
+            config.cooldown_s,
+            config.scan_interval_s,
+            list(config.channels),
+        )
+        try:
+            while True:
+                await asyncio.sleep(config.scan_interval_s)
+                try:
+                    await scanner.scan_and_nudge()
+                except Exception:
+                    # ``scan_and_nudge`` already swallows per-target failures;
+                    # this guard catches programming errors (bad config,
+                    # missing deps) so one bad tick can't kill the watcher.
+                    logger.exception("Idle watcher tick failed")
+        except asyncio.CancelledError:
+            logger.info("Idle watcher cancelled")
+            raise
+
+    setattr(agent, IDLE_ASYNCIO_TASK_ATTR, _scanner_loop)
     return scanner
 
 

--- a/src/nanobot_runtime/tts/irodori.py
+++ b/src/nanobot_runtime/tts/irodori.py
@@ -56,20 +56,28 @@ class IrodoriClient:
 
     # ── TTSSynthesizer Protocol ───────────────────────────────────────
 
-    async def synthesize(self, text: str) -> str | None:
+    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
         tts_text = text.strip() if text else ""
         if not tts_text:
             return None
+
+        # Per-call ``reference_id`` (e.g. forwarded from a Unity envelope's
+        # ``reference_id`` field via TTSHook's resolver) overrides the
+        # constructor default; an explicit empty string also disables the
+        # baked-in reference.
+        effective_ref = reference_id if reference_id is not None else self.reference_id
 
         # Entry log: lets regression E2E verify "synthesize() was NOT
         # called" for TTS-off cases by grepping the gateway log. Truncate
         # long text to keep the line bounded.
         preview = tts_text if len(tts_text) <= 60 else tts_text[:57] + "..."
-        logger.info("IrodoriClient.synthesize: {!r}", preview)
+        logger.info("IrodoriClient.synthesize: {!r} ref={!r}", preview, effective_ref)
 
-        reference_audio_path = self._resolve_reference_audio()
-        if self.reference_id is not None and reference_audio_path is None:
-            # Reference requested but couldn't be resolved — fail closed.
+        reference_audio_path = self._resolve_reference_audio(effective_ref)
+        if effective_ref and reference_audio_path is None:
+            # Non-empty reference requested but couldn't be resolved — fail
+            # closed. Empty/None ``effective_ref`` means "no reference"; the
+            # missing audio path is then the expected outcome.
             return None
 
         audio_bytes = await self._post_synthesize(tts_text, reference_audio_path)
@@ -79,16 +87,16 @@ class IrodoriClient:
 
     # ── Internals ─────────────────────────────────────────────────────
 
-    def _resolve_reference_audio(self) -> Path | None:
-        if self.reference_id is None:
+    def _resolve_reference_audio(self, reference_id: str | None) -> Path | None:
+        if not reference_id:
             return None
         if self.ref_audio_dir is None:
             logger.error(
                 "IrodoriClient: reference_id '{}' given but ref_audio_dir is not set",
-                self.reference_id,
+                reference_id,
             )
             return None
-        candidate = self.ref_audio_dir / self.reference_id / "merged_audio.mp3"
+        candidate = self.ref_audio_dir / reference_id / "merged_audio.mp3"
         if not candidate.exists():
             logger.error("IrodoriClient: reference audio not found: {}", candidate)
             return None

--- a/tests/proactive/test_idle.py
+++ b/tests/proactive/test_idle.py
@@ -35,6 +35,9 @@ def _cfg(**overrides) -> IdleConfig:
         idle_timeout_s=300,
         cooldown_s=900,
         scan_interval_s=30,
+        # Tests default to 0 so legacy gates continue to fire without juggling clocks.
+        # The dedicated startup-grace test overrides this explicitly.
+        startup_grace_s=0,
         quiet_hours=None,
         timezone="Asia/Tokyo",
         channels=("desktop_mate",),
@@ -59,7 +62,10 @@ def _fake_session(updated_at: datetime) -> SimpleNamespace:
 def _build_agent(locks: dict | None = None) -> MagicMock:
     agent = MagicMock()
     agent._session_locks = locks if locks is not None else {}
-    agent.process_direct = AsyncMock()
+    # Scanner now dispatches via bus.publish_inbound so _dispatch handles streaming,
+    # TTS routing, and final OutboundMessage publication uniformly with user messages.
+    agent.bus = MagicMock()
+    agent.bus.publish_inbound = AsyncMock()
     return agent
 
 
@@ -79,7 +85,7 @@ def _build_sessions(list_result: list[dict], fresh_by_key: dict | None = None) -
 
 
 async def test_in_quiet_hours_suppresses_nudge() -> None:
-    """Mid quiet-hours tick must not call process_direct even if a session is idle."""
+    """Mid quiet-hours tick must not dispatch even if a session is idle."""
     now = datetime(2026, 4, 22, 3, 0, tzinfo=_TZ)  # 03:00 JST
     config = _cfg(quiet_hours=QuietHours(start="02:00", end="07:00"))
     agent = _build_agent()
@@ -88,7 +94,7 @@ async def test_in_quiet_hours_suppresses_nudge() -> None:
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
 
 async def test_quiet_hours_spanning_midnight() -> None:
@@ -100,14 +106,14 @@ async def test_quiet_hours_spanning_midnight() -> None:
     quiet_now = datetime(2026, 4, 22, 3, 0, tzinfo=_TZ)
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: quiet_now)
     await scanner.scan_and_nudge()
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
     # Same session but now 08:00 — quiet hours over.
     wake_now = datetime(2026, 4, 22, 8, 0, tzinfo=_TZ)
     sessions = _build_sessions([_session_info("desktop_mate:abc", wake_now, age_s=3600)])
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: wake_now)
     await scanner.scan_and_nudge()
-    agent.process_direct.assert_awaited_once()
+    agent.bus.publish_inbound.assert_awaited_once()
 
 
 async def test_idle_below_threshold_skipped() -> None:
@@ -120,7 +126,7 @@ async def test_idle_below_threshold_skipped() -> None:
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
 
 async def test_active_turn_skipped() -> None:
@@ -135,7 +141,7 @@ async def test_active_turn_skipped() -> None:
         scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
         await scanner.scan_and_nudge()
 
-        agent.process_direct.assert_not_called()
+        agent.bus.publish_inbound.assert_not_called()
     finally:
         locked.release()
 
@@ -153,7 +159,7 @@ async def test_cooldown_blocks_second_nudge() -> None:
 
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
-    assert agent.process_direct.await_count == 1
+    assert agent.bus.publish_inbound.await_count == 1
 
     # 5 minutes later — still within cooldown; idle threshold still satisfied.
     later = now + timedelta(seconds=300)
@@ -161,7 +167,7 @@ async def test_cooldown_blocks_second_nudge() -> None:
     sessions.get_or_create.side_effect = lambda _k: _fake_session(later - timedelta(seconds=3900))
     scanner._clock = lambda: later
     await scanner.scan_and_nudge()
-    assert agent.process_direct.await_count == 1  # unchanged
+    assert agent.bus.publish_inbound.await_count == 1  # unchanged due to cooldown
 
 
 async def test_cooldown_expired_allows_second_nudge() -> None:
@@ -175,7 +181,7 @@ async def test_cooldown_expired_allows_second_nudge() -> None:
 
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
-    assert agent.process_direct.await_count == 1
+    assert agent.bus.publish_inbound.await_count == 1
 
     # 16 minutes later — cooldown window past, session still idle.
     later = now + timedelta(seconds=16 * 60)
@@ -183,7 +189,7 @@ async def test_cooldown_expired_allows_second_nudge() -> None:
     sessions.get_or_create.side_effect = lambda _k: _fake_session(later - timedelta(seconds=3600 + 16 * 60))
     scanner._clock = lambda: later
     await scanner.scan_and_nudge()
-    assert agent.process_direct.await_count == 2
+    assert agent.bus.publish_inbound.await_count == 2  # cooldown expired
 
 
 async def test_channel_not_in_allowlist_skipped() -> None:
@@ -196,7 +202,7 @@ async def test_channel_not_in_allowlist_skipped() -> None:
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
 
 async def test_session_key_without_colon_skipped() -> None:
@@ -211,7 +217,7 @@ async def test_session_key_without_colon_skipped() -> None:
     scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
 
 async def test_revalidation_race_skipped() -> None:
@@ -227,10 +233,10 @@ async def test_revalidation_race_skipped() -> None:
     scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_not_called()
+    agent.bus.publish_inbound.assert_not_called()
 
 
-async def test_all_gates_pass_triggers_process_direct_with_correct_args() -> None:
+async def test_all_gates_pass_publishes_inbound_with_correct_target() -> None:
     now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
     config = _cfg(idle_prompt="You've been silent {minutes}m — say hi.")
     agent = _build_agent()
@@ -242,19 +248,19 @@ async def test_all_gates_pass_triggers_process_direct_with_correct_args() -> Non
     scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
     await scanner.scan_and_nudge()
 
-    agent.process_direct.assert_awaited_once()
-    call = agent.process_direct.await_args
-    assert call.kwargs["session_key"] == "desktop_mate:chat-abc"
-    assert call.kwargs["channel"] == "desktop_mate"
-    assert call.kwargs["chat_id"] == "chat-abc"
-    assert "10m" in call.args[0]  # 600s = 10 minutes
+    agent.bus.publish_inbound.assert_awaited_once()
+    msg = agent.bus.publish_inbound.await_args.args[0]
+    assert msg.channel == "desktop_mate"
+    assert msg.chat_id == "chat-abc"
+    assert msg.session_key_override == "desktop_mate:chat-abc"
+    assert "10m" in msg.content  # 600s = 10 minutes
 
 
-async def test_process_direct_exception_swallowed_and_cooldown_preserved() -> None:
-    """A failing process_direct must not raise out of the scanner, but cooldown still sticks."""
+async def test_publish_inbound_exception_swallowed_and_cooldown_preserved() -> None:
+    """A failing publish_inbound must not raise out of the scanner, but cooldown still sticks."""
     now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
     agent = _build_agent()
-    agent.process_direct.side_effect = RuntimeError("provider down")
+    agent.bus.publish_inbound.side_effect = RuntimeError("bus closed")
     sessions = _build_sessions(
         [_session_info("desktop_mate:abc", now, age_s=3600)],
         fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=3600))},
@@ -265,7 +271,7 @@ async def test_process_direct_exception_swallowed_and_cooldown_preserved() -> No
 
     # Second tick in same minute — cooldown still marked so no retry storm.
     await scanner.scan_and_nudge()
-    assert agent.process_direct.await_count == 1
+    assert agent.bus.publish_inbound.await_count == 1
 
 
 # ---------- install_idle_system_job wiring tests ------------------------------
@@ -363,4 +369,96 @@ async def test_install_idle_job_invokes_scanner() -> None:
     idle_job = SimpleNamespace(id=IDLE_SYSTEM_JOB_ID, name="idle-watcher")
     await composite(idle_job)
 
-    agent.process_direct.assert_awaited_once()
+    agent.bus.publish_inbound.assert_awaited_once()
+
+
+# ---------- A안 (most-recent selection) + #14 startup grace + #16 publish ----
+
+
+async def test_only_most_recent_session_nudged_when_multiple_idle() -> None:
+    """A안: with multiple idle allowlisted sessions, dispatch goes to max(updated_at).
+
+    Phase 5-A's original implementation iterated and dispatched to *every*
+    passing session, which produces the reboot-storm of issue #14 and contradicts
+    the single-target proactive model (one nudge per tick at most).
+    """
+    now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
+    agent = _build_agent()
+    sessions = _build_sessions(
+        [
+            _session_info("desktop_mate:older", now, age_s=7200),    # 2h idle
+            _session_info("desktop_mate:recent", now, age_s=600),    # 10m idle (winner)
+            _session_info("desktop_mate:middling", now, age_s=3600), # 1h idle
+        ],
+        fresh_by_key={
+            "desktop_mate:older": _fake_session(now - timedelta(seconds=7200)),
+            "desktop_mate:recent": _fake_session(now - timedelta(seconds=600)),
+            "desktop_mate:middling": _fake_session(now - timedelta(seconds=3600)),
+        },
+    )
+
+    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    await scanner.scan_and_nudge()
+
+    agent.bus.publish_inbound.assert_awaited_once()
+    msg = agent.bus.publish_inbound.await_args.args[0]
+    assert msg.chat_id == "recent", f"Expected most-recent winner, got {msg.chat_id!r}"
+
+
+async def test_startup_grace_suppresses_nudge_then_releases() -> None:
+    """During startup_grace_s seconds after init, no nudge fires regardless of idle state.
+
+    Guards the reboot-storm scenario from issue #14: dormant sessions present at
+    process start must not be bulk-nudged before the operator has a chance to
+    intervene.
+    """
+    boot = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
+    cursor = {"now": boot}
+    clock = lambda: cursor["now"]
+    agent = _build_agent()
+    sessions = _build_sessions(
+        [_session_info("desktop_mate:abc", boot, age_s=3600)],
+        fresh_by_key={"desktop_mate:abc": _fake_session(boot - timedelta(seconds=3600))},
+    )
+
+    # _started_at captured at __init__ via clock()
+    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(startup_grace_s=120), clock=clock)
+
+    # Tick 30s after boot — within grace, must skip.
+    cursor["now"] = boot + timedelta(seconds=30)
+    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", cursor["now"], age_s=3630)]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(cursor["now"] - timedelta(seconds=3630))
+    await scanner.scan_and_nudge()
+    agent.bus.publish_inbound.assert_not_called()
+
+    # Tick 121s after boot — grace expired, idle gates pass, must dispatch.
+    cursor["now"] = boot + timedelta(seconds=121)
+    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", cursor["now"], age_s=3721)]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(cursor["now"] - timedelta(seconds=3721))
+    await scanner.scan_and_nudge()
+    agent.bus.publish_inbound.assert_awaited_once()
+
+
+async def test_published_inbound_carries_proactive_and_wants_stream() -> None:
+    """Issue #16: scanner must publish through the bus with the metadata required by
+    AgentLoop._dispatch's streaming branch and DesktopMateChannel's proactive flag.
+
+    Without ``_wants_stream`` the dispatcher does not wire the on_stream/on_stream_end
+    callbacks that publish delta + stream_end OutboundMessages, and FE sees no frames.
+    Without ``proactive=True`` the channel cannot mark frames as agent-initiated.
+    """
+    now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
+    agent = _build_agent()
+    sessions = _build_sessions(
+        [_session_info("desktop_mate:abc", now, age_s=600)],
+        fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=600))},
+    )
+
+    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    await scanner.scan_and_nudge()
+
+    agent.bus.publish_inbound.assert_awaited_once()
+    msg = agent.bus.publish_inbound.await_args.args[0]
+    assert msg.metadata.get("proactive") is True
+    assert msg.metadata.get("_wants_stream") is True
+    assert msg.session_key_override == "desktop_mate:abc"

--- a/tests/proactive/test_idle.py
+++ b/tests/proactive/test_idle.py
@@ -19,10 +19,12 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from nanobot_runtime.proactive.idle import (
+    IDLE_ASYNCIO_TASK_ATTR,
     IDLE_SYSTEM_JOB_ID,
     IdleConfig,
     IdleScanner,
     QuietHours,
+    install_idle_asyncio_task,
     install_idle_system_job,
 )
 
@@ -462,3 +464,94 @@ async def test_published_inbound_carries_proactive_and_wants_stream() -> None:
     assert msg.metadata.get("proactive") is True
     assert msg.metadata.get("_wants_stream") is True
     assert msg.session_key_override == "desktop_mate:abc"
+
+
+# ---------- install_idle_asyncio_task tests ----------------------------------
+#
+# These tests cover the cron-bypass installer added to defeat
+# ``cli/commands.py:764`` overwriting the cron composite. The installer
+# should: stash a coroutine factory on the agent, run scanner.scan_and_nudge
+# once per scan_interval_s when that coroutine is driven, and be a no-op
+# when ``enabled=False``.
+
+
+async def test_asyncio_install_disabled_is_noop() -> None:
+    """``enabled=False`` must not stash a coroutine starter on the agent."""
+    # SimpleNamespace because MagicMock auto-creates attributes on access,
+    # which would mask a missing attribute.
+    agent = SimpleNamespace(_session_locks={}, bus=MagicMock())
+    sessions = _build_sessions([])
+
+    result = install_idle_asyncio_task(agent=agent, sessions=sessions, config=_cfg(enabled=False))
+
+    assert result is None
+    assert not hasattr(agent, IDLE_ASYNCIO_TASK_ATTR)
+
+
+async def test_asyncio_install_stashes_coroutine_factory_on_agent() -> None:
+    """Enabled install must place a zero-arg async callable at the agreed attribute name."""
+    agent = _build_agent()
+    sessions = _build_sessions([])
+
+    scanner = install_idle_asyncio_task(agent=agent, sessions=sessions, config=_cfg())
+
+    assert scanner is not None
+    starter = getattr(agent, IDLE_ASYNCIO_TASK_ATTR)
+    assert callable(starter)
+    coro = starter()
+    assert asyncio.iscoroutine(coro)
+    coro.close()
+
+
+async def test_asyncio_loop_calls_scan_and_nudge_each_tick() -> None:
+    """Driving the stashed coroutine for two ticks must yield two scan_and_nudge calls."""
+    agent = _build_agent()
+    sessions = _build_sessions([])
+    config = _cfg(scan_interval_s=1)
+
+    scanner = install_idle_asyncio_task(agent=agent, sessions=sessions, config=config)
+    assert scanner is not None
+    scanner.scan_and_nudge = AsyncMock()  # type: ignore[method-assign]
+
+    starter = getattr(agent, IDLE_ASYNCIO_TASK_ATTR)
+    task = asyncio.create_task(starter())
+    try:
+        # Two scan_interval_s windows + slack — fast clock doesn't help here because
+        # the coroutine uses real ``asyncio.sleep``.
+        await asyncio.sleep(2.5)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert scanner.scan_and_nudge.await_count >= 2
+
+
+async def test_asyncio_loop_swallows_tick_exceptions() -> None:
+    """One bad tick must not kill the watcher — subsequent ticks must still fire."""
+    agent = _build_agent()
+    sessions = _build_sessions([])
+    config = _cfg(scan_interval_s=1)
+
+    scanner = install_idle_asyncio_task(agent=agent, sessions=sessions, config=config)
+    assert scanner is not None
+
+    calls = {"n": 0}
+
+    async def _flaky_scan() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")
+
+    scanner.scan_and_nudge = _flaky_scan  # type: ignore[method-assign]
+
+    starter = getattr(agent, IDLE_ASYNCIO_TASK_ATTR)
+    task = asyncio.create_task(starter())
+    try:
+        await asyncio.sleep(2.5)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert calls["n"] >= 2  # second tick fired despite first one raising

--- a/tests/proactive/test_idle_integration.py
+++ b/tests/proactive/test_idle_integration.py
@@ -29,7 +29,8 @@ async def test_real_cron_fires_scanner_and_nudges_idle_session(tmp_path) -> None
 
     agent = MagicMock()
     agent._session_locks = {}
-    agent.process_direct = AsyncMock()
+    agent.bus = MagicMock()
+    agent.bus.publish_inbound = AsyncMock()
 
     sessions = MagicMock()
     sessions.list_sessions.return_value = [
@@ -51,6 +52,7 @@ async def test_real_cron_fires_scanner_and_nudges_idle_session(tmp_path) -> None
                 idle_timeout_s=300,
                 cooldown_s=900,
                 scan_interval_s=1,
+                startup_grace_s=0,
                 quiet_hours=None,
                 timezone="UTC",
                 channels=("desktop_mate",),
@@ -63,11 +65,13 @@ async def test_real_cron_fires_scanner_and_nudges_idle_session(tmp_path) -> None
     finally:
         cron.stop()
 
-    agent.process_direct.assert_awaited_once()
-    call = agent.process_direct.await_args
-    assert call.kwargs["session_key"] == "desktop_mate:abc"
-    assert call.kwargs["channel"] == "desktop_mate"
-    assert call.kwargs["chat_id"] == "abc"
+    agent.bus.publish_inbound.assert_awaited_once()
+    msg = agent.bus.publish_inbound.await_args.args[0]
+    assert msg.session_key_override == "desktop_mate:abc"
+    assert msg.channel == "desktop_mate"
+    assert msg.chat_id == "abc"
+    assert msg.metadata.get("proactive") is True
+    assert msg.metadata.get("_wants_stream") is True
 
 
 async def test_real_cron_preserves_existing_on_job(tmp_path) -> None:
@@ -79,13 +83,17 @@ async def test_real_cron_preserves_existing_on_job(tmp_path) -> None:
     cron.on_job = user_callback
     await cron.start()
     try:
+        idle_agent = MagicMock(_session_locks={})
+        idle_agent.bus = MagicMock()
+        idle_agent.bus.publish_inbound = AsyncMock()
         install_idle_system_job(
-            agent=MagicMock(_session_locks={}, process_direct=AsyncMock()),
+            agent=idle_agent,
             sessions=MagicMock(list_sessions=MagicMock(return_value=[]), get_or_create=MagicMock()),
             cron=cron,
             config=IdleConfig(
                 enabled=True,
                 scan_interval_s=60,  # large so it doesn't race the user job
+                startup_grace_s=0,
                 quiet_hours=None,
                 timezone="UTC",
                 channels=("desktop_mate",),

--- a/tests/regression/harness.py
+++ b/tests/regression/harness.py
@@ -75,9 +75,11 @@ class RecordingSynthesizer:
 
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.ref_calls: list[str | None] = []
 
-    async def synthesize(self, text: str) -> str | None:
+    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
         self.calls.append(text)
+        self.ref_calls.append(reference_id)
         # Short, fixed base64 so tests can assert the FULL tts_chunk
         # without caring about actual audio.
         return "QUJDRA=="  # "ABCD"

--- a/tests/test_tts_hook.py
+++ b/tests/test_tts_hook.py
@@ -71,13 +71,15 @@ class _FakeSynthesizer:
 
     def __init__(self, latency: float = 0.0, fail_on: set[str] | None = None) -> None:
         self.calls: list[str] = []
+        self.ref_calls: list[str | None] = []
         self._latency = latency
         self._fail_on = fail_on or set()
 
-    async def synthesize(self, text: str) -> str | None:
+    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
         if self._latency:
             await asyncio.sleep(self._latency)
         self.calls.append(text)
+        self.ref_calls.append(reference_id)
         if text in self._fail_on:
             raise RuntimeError(f"TTS synth failed for: {text}")
         return f"b64::{text}"
@@ -357,3 +359,87 @@ async def test_sink_without_is_enabled_defaults_to_enabled() -> None:
 
     assert synth.calls == ["Hello there."]
     assert len(sink.chunks) == 1
+
+
+# --------------------------------------------------------------------------
+# reference_id resolver
+# --------------------------------------------------------------------------
+
+
+async def test_reference_id_resolver_passes_voice_to_synthesizer() -> None:
+    """When configured, the resolver's return value reaches synthesize()."""
+    sink = _FakeSink()
+    synth = _FakeSynthesizer()
+    seen: list[str | None] = []
+
+    def resolver(session_key: str | None) -> str | None:
+        seen.append(session_key)
+        return "alice"
+
+    hook = TTSHook(
+        chunker_factory=_FakeChunker,
+        preprocessor=_FakePreprocessor(),
+        emotion_mapper=_FakeEmotionMapper(),
+        synthesizer=synth,
+        sink=sink,
+        reference_id_resolver=resolver,
+    )
+
+    ctx = _ctx(session_key="desktop_mate:abc")
+    await hook.on_stream(ctx, "Hello there.")
+    await hook.on_stream_end(ctx, resuming=False)
+
+    assert seen == ["desktop_mate:abc"]
+    assert synth.ref_calls == ["alice"]
+
+
+async def test_reference_id_resolver_returning_none_falls_through() -> None:
+    """``None`` return must be passed to synthesize so it uses its default."""
+    sink = _FakeSink()
+    synth = _FakeSynthesizer()
+
+    hook = TTSHook(
+        chunker_factory=_FakeChunker,
+        preprocessor=_FakePreprocessor(),
+        emotion_mapper=_FakeEmotionMapper(),
+        synthesizer=synth,
+        sink=sink,
+        reference_id_resolver=lambda _k: None,
+    )
+
+    await hook.on_stream(_ctx(), "Hi.")
+    await hook.on_stream_end(_ctx(), resuming=False)
+
+    assert synth.ref_calls == [None]
+
+
+async def test_reference_id_resolver_exception_is_swallowed() -> None:
+    """A buggy resolver must not block synthesis — synth runs with reference_id=None."""
+    sink = _FakeSink()
+    synth = _FakeSynthesizer()
+
+    def boom(_k: str | None) -> str | None:
+        raise RuntimeError("resolver bug")
+
+    hook = TTSHook(
+        chunker_factory=_FakeChunker,
+        preprocessor=_FakePreprocessor(),
+        emotion_mapper=_FakeEmotionMapper(),
+        synthesizer=synth,
+        sink=sink,
+        reference_id_resolver=boom,
+    )
+
+    await hook.on_stream(_ctx(), "Hi.")
+    await hook.on_stream_end(_ctx(), resuming=False)
+
+    assert synth.ref_calls == [None]
+    assert len(sink.chunks) == 1
+
+
+async def test_no_resolver_passes_none_to_synthesize() -> None:
+    """Backward compat: hooks built without a resolver must not pass spurious values."""
+    hook, sink, synth = _make_hook()
+    await hook.on_stream(_ctx(), "Hi.")
+    await hook.on_stream_end(_ctx(), resuming=False)
+    assert synth.ref_calls == [None]

--- a/tests/tts/test_irodori.py
+++ b/tests/tts/test_irodori.py
@@ -129,3 +129,73 @@ async def test_includes_expected_form_fields(
     assert b"num_steps=40" in body
     assert b"cfg_scale_text=3.0" in body
     assert b"cfg_scale_speaker=5.0" in body
+
+
+async def test_per_call_reference_id_overrides_constructor_default(
+    httpx_mock: HTTPXMock, base_url: str, tmp_path: Path
+) -> None:
+    """A reference_id passed to ``synthesize`` must override the constructor value."""
+    bob_dir = tmp_path / "bob"
+    bob_dir.mkdir()
+    (bob_dir / "merged_audio.mp3").write_bytes(b"bob-ref-audio")
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{base_url}/synthesize",
+        content=b"ok",
+        status_code=200,
+    )
+
+    # Constructor sets a *different* reference_id ("alice") that does not
+    # exist on disk — if synthesize used it, it would fail-closed and return
+    # None without making the HTTP call. Per-call override must win.
+    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    result = await client.synthesize("Hi.", reference_id="bob")
+    assert result == base64.b64encode(b"ok").decode("utf-8")
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 1
+    # Multipart upload signals reference_audio file was attached.
+    assert b"reference_audio" in reqs[0].content
+
+
+async def test_per_call_reference_id_none_falls_back_to_constructor(
+    httpx_mock: HTTPXMock, base_url: str, tmp_path: Path
+) -> None:
+    """``reference_id=None`` (the default) must keep the constructor behaviour."""
+    alice_dir = tmp_path / "alice"
+    alice_dir.mkdir()
+    (alice_dir / "merged_audio.mp3").write_bytes(b"alice-ref-audio")
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{base_url}/synthesize",
+        content=b"ok",
+        status_code=200,
+    )
+
+    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    result = await client.synthesize("Hi.")  # no per-call override
+    assert result == base64.b64encode(b"ok").decode("utf-8")
+    assert b"reference_audio" in httpx_mock.get_requests()[0].content
+
+
+async def test_per_call_reference_id_empty_string_disables_baked_in(
+    httpx_mock: HTTPXMock, base_url: str, tmp_path: Path
+) -> None:
+    """Empty-string override must skip reference audio even when constructor set one."""
+    alice_dir = tmp_path / "alice"
+    alice_dir.mkdir()
+    (alice_dir / "merged_audio.mp3").write_bytes(b"alice-ref-audio")
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{base_url}/synthesize",
+        content=b"ok",
+        status_code=200,
+    )
+
+    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    result = await client.synthesize("Hi.", reference_id="")
+    assert result == base64.b64encode(b"ok").decode("utf-8")
+    assert b"reference_audio" not in httpx_mock.get_requests()[0].content


### PR DESCRIPTION
## Summary

Phase 5-A's idle watcher had three coupled problems; this PR fixes them as one cohesive change:

- **Closes #16** — nudges never reached the FE. The scanner discarded ``process_direct``'s returned ``OutboundMessage``, so nothing was published to the bus. ``DesktopMateChannel.send`` / ``send_delta`` were never invoked, ``_current_stream_id`` stayed unset, and TTS chunks (which fire via the AgentHook side path) had nowhere to route.
- **Closes #14** — reboot-storm. In-memory cooldown was wiped on restart and there was no startup grace, so every dormant session passed the gates simultaneously and got bulk-nudged at boot.
- **A안 (single-target)** — replaces the per-session fan-out with one nudge per tick, sent to the most-recently updated allowlisted session. Matches yuri's per-channel isolation model (issue #19) and structurally caps the dormant-session storm regardless of cooldown state.

Supersedes the earlier attempt (PR #15, closed) by combining the reboot-storm guard with the missing bus publish, and replacing the pre-start filter + ``max_idle_s`` ceiling with a simpler single-target selector.

## What changed

1. **Selection** — ``IdleScanner._select_target`` collects every session that passes (allowlist, idle, not-active-turn, not-in-cooldown, fresh re-validation) and returns the single ``max(updated_at)``. At most one dispatch per tick.

2. **Dispatch** — ``IdleScanner._dispatch_nudge`` publishes a synthesized ``InboundMessage`` with ``_wants_stream=True`` and ``proactive=True`` metadata via ``agent.bus.publish_inbound(...)``. The nanobot ``AgentLoop._dispatch`` consumer wires streaming callbacks (deltas + stream_end), runs the agent loop, and publishes the final ``OutboundMessage`` — identical to a user message, so DesktopMateChannel streaming + TTS chunk routing work without proactive-specific glue.

3. **Startup grace** — new ``IdleConfig.startup_grace_s`` (default 120s) suppresses every nudge during the post-boot window. ``_started_at`` captured at scanner ``__init__`` via the same clock test override, so existing tests that pin a single moment still need ``startup_grace_s=0``.

4. **Gateway wire-up** — ``yuri/run_gateway.py`` reads ``YURI_IDLE_STARTUP_GRACE_S`` (default 120) into the config builder. (Local-only since ``yuri/`` workspace is gitignored.)

## What's intentionally out of scope

- **Cross-channel "user is active somewhere"** — tracked as #19. Conversation history is per-channel under ``unifiedSession=false``; cross-channel idle suppression would need workspace-level activity aggregation.
- **#4 (``cli:user`` phantom nudge)** — the idle scanner's allowlist filter is correct; root cause lives in another cron path (likely ``deliver=true`` target resolution). Left for separate triage.
- **Persisted cooldown** — startup grace + single-target selection together obviate the in-memory cooldown's worst failure mode. Disk persistence can land later if needed.
- **Dormancy ceiling (``max_idle_s``)** — not adding it; cooldown + single-target already prevent storm. Can revisit if long-dormant sessions get pestered in practice.

## Test plan

- [x] ``pytest tests/proactive/`` — 21/21 (16 existing adapted to the new bus contract, 3 new for A안 / startup grace / metadata, 2 integration tests rewired)
- [x] ``pytest`` — full suite 202/202, 0 regressions
- [ ] Live smoke against real gateway — verify a nudge actually reaches Unity (recommended before flipping ``YURI_IDLE_ENABLED`` back on by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)