### PR TITLE
chore: anti-pattern enforcement, TTS hook package split, CI setup

### DIFF
--- a/.claude/rules/CODING_RULES.md
+++ b/.claude/rules/CODING_RULES.md
@@ -132,7 +132,6 @@ class WebSocketConfig(BaseModel):
   ```python
   _PERSONAS_PATH = Path(__file__).resolve().parents[3] / "yaml_files" / "personas.yml"
   ```
-
 ---
 
 ## 7. Pydantic Models
@@ -223,3 +222,4 @@ base_dir = yaml_path.parent
 | DEBUG logs in production paths | Dev only |
 | `__all__` in non-library modules | Not needed |
 | Section comments with `# ---` dashes | Use `# ── Name ───` unicode style |
+| BaseModel or ABC abstract classes are in the same file | Separate into `base.py` and `abc.py` if needed |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --group dev
+
+      - name: Black check
+        run: uv run black --check src/ tests/
+
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Anti-pattern check
+        run: uv run python scripts/check_antipatterns.py
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest -m "not integration and not e2e" --cov=src/nanobot_runtime --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,8 @@ jobs:
           python-version: "3.12"
       - run: uv sync --group dev
 
-      - name: Black check
-        run: uv run black --check src/ tests/
-
-      - name: Ruff check
-        run: uv run ruff check src/ tests/
-
-      - name: Anti-pattern check
-        run: uv run python scripts/check_antipatterns.py
+      - name: Run linters
+        run: bash scripts/lint.sh
 
   test:
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-04-26-tts-attachment-pipeline-telegram.md
+++ b/docs/superpowers/plans/2026-04-26-tts-attachment-pipeline-telegram.md
@@ -1,0 +1,1560 @@
+# TTS Attachment Pipeline (Telegram) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the ATTACHMENT TTS dispatch mode so Telegram (and any future ATTACHMENT-mode channel) receives one OGG/Opus voice-note per agent turn, while preserving the existing STREAMING path to DesktopMate.
+
+**Architecture:** A new `AttachmentTTSSink` buffers `TTSChunk`s per session, and on session-end concatenates the WAV fragments, encodes them to OGG/Opus via an ffmpeg subprocess, and publishes the resulting voice-note as an `OutboundMessage` on the existing `MessageBus` so nanobot's `ChannelManager` routes it through `TelegramChannel.send()` (which already calls `bot.send_voice` for `.ogg` media). The `TTSSink` ABC gains an `on_session_end` notification so the sink learns when the TTS Barrier has drained. A new `MultiplexingTTSSink` routes per-chunk dispatches to either the existing `LazyChannelTTSSink` (STREAMING) or the new `AttachmentTTSSink` (ATTACHMENT) based on the channel mode lookup. The launcher swaps its single sink for the multiplexer.
+
+**Tech Stack:** Python 3.10+ with native union/generic syntax, Pydantic v2 (no dataclasses for config), Loguru, `asyncio` subprocess + system `ffmpeg` for Opus encoding, pytest + `pytest-asyncio`, nanobot `MessageBus` / `OutboundMessage` / `AgentHook` interfaces.
+
+**Constraints (from user):**
+- All code lives in `yuri/nanobot_runtime/`. Do NOT modify `yuri/nanobot/` (upstream fork) or anything in `yuri/` outside `nanobot_runtime/`.
+- `yuri/` itself is not a git repo; only `yuri/nanobot_runtime/` is. All commits land there, on a `feat/` branch off `develop`, then PR'd to `develop`.
+- TTS rules in CODING_RULES.md apply: absolute imports, no `from __future__`, Pydantic v2 + `Field(description=)`, Loguru only, `T | None`, snake_case files, `# ── Section ──` comment style, fail loud, TDD mandatory.
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|------|----------------|
+| `src/nanobot_runtime/services/tts/encoder.py` | `VoiceEncoder` ABC + `OpusEncoder` concrete (ffmpeg subprocess). ABC defines `encode_wav_chunks(chunks) -> bytes`. Tests fakes inherit the ABC so a missing method fails at construction. |
+| `src/nanobot_runtime/services/tts/attachment_sink.py` | `AttachmentTTSSink` — implements `TTSSink`. Buffers `(sequence, audio_bytes)` per session, flushes via encoder + bus on `on_session_end`. |
+| `src/nanobot_runtime/services/tts/multiplex_sink.py` | `MultiplexingTTSSink` — implements `TTSSink`. Looks up `ChannelModeMap` per call and forwards to the appropriate downstream sink. |
+| `tests/services/tts/test_encoder.py` | Encoder unit tests. |
+| `tests/services/tts/test_attachment_sink.py` | AttachmentTTSSink unit tests with fake bus + fake encoder. |
+| `tests/services/tts/test_multiplex_sink.py` | MultiplexingTTSSink unit tests with fake child sinks. |
+| `tests/services/hooks/test_tts_hook_session_end.py` | TTSHook regression: `on_session_end` is awaited after barrier on `on_stream_end(resuming=False)` and NOT on `resuming=True`. |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `src/nanobot_runtime/services/hooks/tts.py` | Add `on_session_end(session_key: str \| None) -> None` as `@abstractmethod` on `TTSSink` ABC — every subclass must explicitly implement (no silent inheritance of behavior). `TTSHook.on_stream_end(resuming=False)` calls it after the TTS Barrier. |
+| `src/nanobot_runtime/services/channels/desktop_mate.py` | `LazyChannelTTSSink` overrides `on_session_end` as an explicit no-op with a docstring (so streaming path stays unchanged). No behavior change. |
+| `src/nanobot_runtime/services/tts/modes.py` | Remove the "ATTACHMENT pipeline TBD — silently equivalent to NONE" warning block (lines 122-137). Replace with a passive log line listing implemented modes per channel. |
+| `src/nanobot_runtime/launcher.py` | `_build_tts_hook` constructs `AttachmentTTSSink` + `LazyChannelTTSSink`, wraps both in `MultiplexingTTSSink`, passes to `TTSHook`. |
+| `tests/services/channels/test_tts_sink_wiring.py` | Update to expect a multiplexer at the top of the wiring (existing test must not break). |
+
+---
+
+## Task 1: Add `on_session_end` to the TTSSink ABC
+
+**Why first:** Every other component depends on this hook. Adding it as a concrete no-op (not abstract) means the existing `LazyChannelTTSSink` keeps working without changes — we only add an explicit override there for clarity.
+
+**Files:**
+- Modify: `src/nanobot_runtime/services/hooks/tts.py:96-122` (the `TTSSink` ABC)
+- Test: `tests/services/hooks/test_tts_hook_session_end.py` (new)
+
+- [ ] **Step 1.1: Write the failing test for the new hook contract**
+
+Create `tests/services/hooks/test_tts_hook_session_end.py`:
+
+```python
+import asyncio
+from typing import Any
+
+import pytest
+from nanobot.agent.hook import AgentHookContext
+
+from nanobot_runtime.services.hooks.tts import TTSChunk, TTSHook, TTSSink
+
+
+class _RecordingSink(TTSSink):
+    def __init__(self) -> None:
+        self.session_ends: list[str | None] = []
+        self.chunks: list[TTSChunk] = []
+
+    def is_enabled(self, session_key: str | None) -> bool:
+        return True
+
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
+        self.chunks.append(chunk)
+
+    async def on_session_end(self, session_key: str | None) -> None:
+        self.session_ends.append(session_key)
+
+
+class _StubChunker:
+    def feed(self, delta: str) -> list[str]:
+        return [delta] if delta else []
+
+    def flush(self) -> str | None:
+        return None
+
+
+class _StubPreprocessor:
+    def process(self, sentence: str) -> tuple[str, str | None]:
+        return sentence, None
+
+
+class _StubEmotionMapper:
+    def map(self, emotion: str | None) -> list[dict[str, Any]]:
+        return []
+
+
+class _StubSynth:
+    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
+        return "AAAA"
+
+
+@pytest.fixture
+def hook_with_recording_sink() -> tuple[TTSHook, _RecordingSink]:
+    sink = _RecordingSink()
+    hook = TTSHook(
+        chunker_factory=_StubChunker,
+        preprocessor=_StubPreprocessor(),
+        emotion_mapper=_StubEmotionMapper(),
+        synthesizer=_StubSynth(),
+        sink=sink,
+        barrier_timeout_seconds=2.0,
+    )
+    return hook, sink
+
+
+class TestTTSHookSessionEnd:
+    @pytest.mark.asyncio
+    async def test_on_session_end_invoked_after_barrier_on_terminal_stream_end(
+        self, hook_with_recording_sink: tuple[TTSHook, _RecordingSink]
+    ) -> None:
+        hook, sink = hook_with_recording_sink
+        ctx = AgentHookContext(session_key="telegram:42")
+        await hook.on_stream(ctx, "hello.")
+        await hook.on_stream_end(ctx, resuming=False)
+        assert sink.session_ends == ["telegram:42"]
+
+    @pytest.mark.asyncio
+    async def test_on_session_end_not_invoked_when_resuming_for_tool_call(
+        self, hook_with_recording_sink: tuple[TTSHook, _RecordingSink]
+    ) -> None:
+        hook, sink = hook_with_recording_sink
+        ctx = AgentHookContext(session_key="telegram:42")
+        await hook.on_stream(ctx, "hello.")
+        await hook.on_stream_end(ctx, resuming=True)
+        assert sink.session_ends == []
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/hooks/test_tts_hook_session_end.py -v`
+Expected: FAIL — `_RecordingSink` defines `on_session_end` so it instantiates fine, but `TTSHook.on_stream_end` does not call it yet (Step 1.4 adds that). So the assertion `assert sink.session_ends == ["telegram:42"]` fails with `AssertionError: assert [] == ['telegram:42']`. The second test (`resuming=True`) may PASS coincidentally — that's expected; it becomes meaningful only after Step 1.4 wires the call site.
+
+- [ ] **Step 1.3: Add `on_session_end` to TTSSink ABC as abstractmethod**
+
+Edit `src/nanobot_runtime/services/hooks/tts.py`. In the `TTSSink` class (around line 96-122), after the existing `is_enabled` abstractmethod, add:
+
+```python
+    @abstractmethod
+    async def on_session_end(self, session_key: str | None) -> None:
+        """Notify the sink that the TTS Barrier has drained for this session.
+
+        The hook calls this exactly once per terminal ``on_stream_end``
+        (i.e. ``resuming=False``), AFTER awaiting all pending synth tasks.
+        Streaming sinks should implement this as a no-op; attachment-style
+        sinks use it as the flush trigger.
+
+        ``session_key`` is required positionally — pass ``None`` explicitly
+        when no key is available.
+
+        Made abstract (not a default no-op) so any sink that forgets the
+        method fails loud at construction time with a clear ``TypeError``,
+        not silently at the dispatch hot path.
+        """
+```
+
+This is a **breaking change** for any downstream `TTSSink` subclass that has not yet implemented `on_session_end` — including:
+
+- `LazyChannelTTSSink` → handled in Task 2 (explicit no-op override).
+- `_RecordingSink` test fixture in `test_tts_hook_session_end.py` → already implements it (Step 1.1).
+- Any other `TTSSink` subclasses in the test suite — Task 1.6 finds them via the regression sweep, and they get an explicit no-op override added in the same commit. The plan handles this via the regression sweep step, not separately.
+
+- [ ] **Step 1.4: Wire `on_session_end` into `TTSHook.on_stream_end`**
+
+Edit `src/nanobot_runtime/services/hooks/tts.py`, in `on_stream_end`. Currently the method ends by popping the per-session bucket. Change the tail to:
+
+```python
+        # Turn fully wrapped — drop the per-session bucket so the next turn
+        # for the same session starts clean (sequence back to 0, fresh chunker).
+        self._states.pop(key, None)
+
+        # Notify sink AFTER state cleanup so a sink callback that re-enters
+        # the hook (e.g. logging) sees a clean slate. Failures here must not
+        # bubble — the agent turn has already completed successfully.
+        try:
+            await self._sink.on_session_end(key)
+        except Exception:
+            logger.exception(
+                "TTS sink on_session_end raised (session={})", key
+            )
+```
+
+The `try/except` is intentional and matches the existing `_synth_and_emit` pattern — sink failures must not corrupt agent-loop state. This is NOT silent swallowing: traceback is logged via `logger.exception`.
+
+- [ ] **Step 1.5: Run test to verify it passes**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/hooks/test_tts_hook_session_end.py -v`
+Expected: 2 PASSED.
+
+- [ ] **Step 1.6: Run full hook test file to find any TTSSink subclasses missing the new abstractmethod**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/hooks/test_tts_hook.py tests/services/hooks/test_tts_hook_session_end.py -v`
+
+Expected outcome: **failures of type `TypeError: Can't instantiate abstract class <FakeSink> with abstract method on_session_end`** for every test fake/subclass that hasn't implemented the new method. For each such fake, add an explicit no-op:
+
+```python
+    async def on_session_end(self, session_key: str | None) -> None:
+        return None
+```
+
+Repeat run until clean. Do NOT skip this — silently letting a subclass fail at runtime defeats the point of making it abstract.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/hooks/tts.py tests/services/hooks/test_tts_hook_session_end.py
+git commit -m "feat(tts): add TTSSink.on_session_end + TTSHook barrier notification"
+```
+
+---
+
+## Task 2: Explicit no-op override on `LazyChannelTTSSink`
+
+**Why:** Make the streaming path's "I don't care about session_end" decision visible in the code, not relying on inheritance silence.
+
+**Files:**
+- Modify: `src/nanobot_runtime/services/channels/desktop_mate.py:344-419` (the `LazyChannelTTSSink` class)
+- Test: `tests/services/channels/test_desktop_mate.py` (add one test, do not create a new file — co-locate with existing `LazyChannelTTSSink` tests)
+
+- [ ] **Step 2.1: Write the test**
+
+In `tests/services/channels/test_desktop_mate.py`, append a test that imports the existing fixtures pattern from the file and asserts:
+
+```python
+class TestLazyChannelTTSSinkSessionEnd:
+    @pytest.mark.asyncio
+    async def test_on_session_end_is_noop_and_does_not_raise(self) -> None:
+        from nanobot_runtime.services.channels.desktop_mate import LazyChannelTTSSink
+        from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+
+        sink = LazyChannelTTSSink(
+            mode_map=ChannelModeMap(default=TTSMode.NONE, channels={"desktop_mate": TTSMode.STREAMING})
+        )
+        # Should not raise even with no channel registered.
+        await sink.on_session_end("desktop_mate:abc")
+        await sink.on_session_end(None)
+```
+
+- [ ] **Step 2.2: Run the test to verify it currently passes (default no-op inherited from ABC)**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/channels/test_desktop_mate.py::TestLazyChannelTTSSinkSessionEnd -v`
+Expected: PASS (because Task 1 already added a no-op default).
+
+- [ ] **Step 2.3: Add explicit override on `LazyChannelTTSSink`**
+
+In `src/nanobot_runtime/services/channels/desktop_mate.py`, inside the `LazyChannelTTSSink` class (around line 401, after `get_reference_id_for_session`), add:
+
+```python
+    async def on_session_end(self, session_key: str | None) -> None:
+        """Streaming sinks have nothing to flush — chunks were emitted live.
+
+        Explicit override (not relying on the ABC default) so a future
+        contract change to ``on_session_end`` is visible in the streaming
+        path during code review.
+        """
+        return None
+```
+
+- [ ] **Step 2.4: Re-run the test to confirm still passing**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/channels/test_desktop_mate.py::TestLazyChannelTTSSinkSessionEnd -v`
+Expected: PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/channels/desktop_mate.py tests/services/channels/test_desktop_mate.py
+git commit -m "feat(tts): explicit on_session_end no-op on LazyChannelTTSSink"
+```
+
+---
+
+## Task 3: `OpusEncoder` (WAV → OGG/Opus via ffmpeg)
+
+**Interface contract:** the encoder is an ABC, not a Protocol — consistent with `TTSSink`. The concrete `OpusEncoder` (ffmpeg subprocess) inherits from it. Test fakes also inherit from the ABC, so a fake that forgets a method fails loud at construction time. Existing dependency Protocols on `TTSHook` (`SentenceChunker`, `TextPreprocessor`, `EmotionMapper`, `TTSSynthesizer`) are intentionally left as Protocols in this PR — converting them is a separate, broader refactor and out of scope.
+
+**Why:** Telegram's `bot.send_voice` only displays the voice-note UI (waveform + speed controls) when the file is OGG container with Opus codec. Other formats (mp3, wav) fall back to a generic audio attachment — visible but worse UX. This encoder is a focused, mockable boundary.
+
+**Files:**
+- Create: `src/nanobot_runtime/services/tts/encoder.py`
+- Test: `tests/services/tts/test_encoder.py`
+
+**Pre-flight:** Engineer must verify `ffmpeg` is on PATH. Run `ffmpeg -version` in the dev container. If absent, install via `apt install ffmpeg`. Document in `docs/setup.md` at the end of this task.
+
+- [ ] **Step 3.1: Write the failing test**
+
+Create `tests/services/tts/test_encoder.py`:
+
+```python
+import asyncio
+import shutil
+import struct
+import wave
+from io import BytesIO
+
+import pytest
+
+from nanobot_runtime.services.tts.encoder import OpusEncoder, VoiceEncoder, VoiceEncoderError
+
+
+def _silent_wav(duration_seconds: float = 0.1, sample_rate: int = 16000) -> bytes:
+    """Build a tiny WAV byte-string of silence for round-trip testing."""
+    buf = BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        n_frames = int(duration_seconds * sample_rate)
+        w.writeframes(b"\x00\x00" * n_frames)
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="module")
+def encoder() -> OpusEncoder:
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg not on PATH — install via `apt install ffmpeg`.")
+    return OpusEncoder()
+
+
+class TestOpusEncoder:
+    def test_opus_encoder_is_voice_encoder_subclass(self) -> None:
+        assert issubclass(OpusEncoder, VoiceEncoder)
+
+    @pytest.mark.asyncio
+    async def test_encode_wav_chunks_returns_ogg_opus_bytes(
+        self, encoder: OpusEncoder
+    ) -> None:
+        chunks = [_silent_wav(0.1), _silent_wav(0.1)]
+        result = await encoder.encode_wav_chunks(chunks)
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        # OGG container magic
+        assert result.startswith(b"OggS"), "expected OGG container magic"
+
+    @pytest.mark.asyncio
+    async def test_encode_empty_chunk_list_raises(
+        self, encoder: OpusEncoder
+    ) -> None:
+        with pytest.raises(VoiceEncoderError, match="no audio chunks"):
+            await encoder.encode_wav_chunks([])
+
+    @pytest.mark.asyncio
+    async def test_encode_invalid_wav_raises_with_ffmpeg_stderr(
+        self, encoder: OpusEncoder
+    ) -> None:
+        with pytest.raises(VoiceEncoderError, match="ffmpeg"):
+            await encoder.encode_wav_chunks([b"not-a-wav-at-all"])
+```
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_encoder.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'nanobot_runtime.services.tts.encoder'`.
+
+- [ ] **Step 3.3: Implement the encoder ABC + ffmpeg-backed concrete**
+
+Create `src/nanobot_runtime/services/tts/encoder.py`:
+
+```python
+"""WAV → OGG/Opus encoder for ATTACHMENT-mode TTS delivery.
+
+The ABC ``VoiceEncoder`` defines the contract; ``OpusEncoder`` is the
+production implementation backed by an ffmpeg subprocess. Test fakes also
+inherit from the ABC, so a fake that forgets a method fails at construction
+time with a clear ``TypeError`` rather than at the dispatch hot path.
+
+We accept a list of raw WAV byte-strings (one per synthesized sentence),
+concatenate them via the ffmpeg ``concat`` demuxer, and produce a single
+OGG/Opus stream suitable for Telegram's ``bot.send_voice`` (which shows
+the waveform + speed UI only for OGG/Opus, not mp3 or generic audio).
+
+ffmpeg is a runtime dependency: the encoder fails loud at first use if
+the binary is missing rather than silently skipping voice delivery.
+"""
+import asyncio
+import shutil
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VoiceEncoderError(RuntimeError):
+    """Raised when an encoder cannot produce output (missing binary, bad input, ...)."""
+
+
+class VoiceEncoder(ABC):
+    """Contract for components that turn WAV chunks into a single voice-note byte-string.
+
+    Promoted to ABC (rather than a typing.Protocol) so every implementation —
+    production (`OpusEncoder`) and test fake — explicitly inherits the
+    contract. Forgetting a method fails at construction time with a
+    ``TypeError``, matching the pattern used by `TTSSink`.
+    """
+
+    @abstractmethod
+    async def encode_wav_chunks(self, chunks: list[bytes]) -> bytes:
+        """Encode a sequence of WAV byte-strings into one packaged voice-note stream.
+
+        Args:
+            chunks: WAV byte-strings, in playback order.
+
+        Returns:
+            Encoded bytes ready to be saved to disk or attached to an
+            outbound message.
+
+        Raises:
+            VoiceEncoderError: on missing dependencies, invalid input, or
+                encoder-process failure. Implementations must never silently
+                return empty bytes.
+        """
+
+
+class OpusEncoderConfig(BaseModel):
+    """Tunable parameters for `OpusEncoder`. Pydantic per CODING_RULES §6."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sample_rate_hz: int = Field(
+        default=48_000,
+        ge=8_000,
+        le=48_000,
+        description="Output sample rate. Telegram's voice-note recommendation is 48kHz.",
+    )
+    bitrate_kbps: int = Field(
+        default=32,
+        ge=6,
+        le=510,
+        description="Opus target bitrate in kbps. 32 is a good speech default.",
+    )
+    application: str = Field(
+        default="voip",
+        description="Opus application mode: 'voip', 'audio', or 'lowdelay'.",
+    )
+
+
+class OpusEncoder(VoiceEncoder):
+    """Concatenate WAV chunks and encode them to a single OGG/Opus byte-string via ffmpeg."""
+
+    def __init__(self, config: OpusEncoderConfig | None = None) -> None:
+        self._config: OpusEncoderConfig = config or OpusEncoderConfig()
+        self._ffmpeg_path: str | None = shutil.which("ffmpeg")
+
+    async def encode_wav_chunks(self, chunks: list[bytes]) -> bytes:
+        """See `VoiceEncoder.encode_wav_chunks`."""
+        if not chunks:
+            raise VoiceEncoderError("no audio chunks to encode")
+        if self._ffmpeg_path is None:
+            raise VoiceEncoderError(
+                "ffmpeg binary not found on PATH. Install with `apt install ffmpeg`."
+            )
+
+        with tempfile.TemporaryDirectory(prefix="nanobot_tts_") as tmp_str:
+            tmp = Path(tmp_str)
+            wav_paths: list[Path] = []
+            for idx, wav in enumerate(chunks):
+                p = tmp / f"chunk_{idx:04d}.wav"
+                p.write_bytes(wav)
+                wav_paths.append(p)
+
+            concat_list = tmp / "concat.txt"
+            concat_list.write_text(
+                "\n".join(f"file '{p.as_posix()}'" for p in wav_paths)
+            )
+
+            return await self._run_ffmpeg(concat_list)
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    async def _run_ffmpeg(self, concat_list: Path) -> bytes:
+        cfg = self._config
+        cmd = [
+            self._ffmpeg_path or "ffmpeg",  # narrowed: None case raised above
+            "-hide_banner",
+            "-loglevel", "error",
+            "-y",
+            "-f", "concat",
+            "-safe", "0",
+            "-i", str(concat_list),
+            "-ar", str(cfg.sample_rate_hz),
+            "-ac", "1",
+            "-c:a", "libopus",
+            "-b:a", f"{cfg.bitrate_kbps}k",
+            "-application", cfg.application,
+            "-f", "ogg",
+            "pipe:1",
+        ]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            err_text = stderr.decode("utf-8", errors="replace").strip()
+            raise VoiceEncoderError(f"ffmpeg failed (rc={proc.returncode}): {err_text}")
+        if not stdout:
+            raise VoiceEncoderError("ffmpeg produced empty output")
+        logger.debug(
+            "OpusEncoder: encoded {} input chunk file(s) → {} bytes OGG/Opus",
+            sum(1 for _ in concat_list.read_text().splitlines() if _.strip()),
+            len(stdout),
+        )
+        return stdout
+```
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_encoder.py -v`
+Expected: 3 PASSED (or skipped if no ffmpeg).
+
+- [ ] **Step 3.5: Document the ffmpeg dependency**
+
+Append to `docs/setup.md` (whatever section lists system dependencies — if none exists, add a `## System Dependencies` section near the top):
+
+```markdown
+## System Dependencies
+
+- **ffmpeg** — required for ATTACHMENT-mode TTS (Telegram voice-note encoding).
+  Install via `apt install ffmpeg` on Debian/Ubuntu, `brew install ffmpeg` on macOS.
+  Used by `nanobot_runtime.services.tts.encoder.OpusEncoder` to concatenate
+  per-sentence WAV chunks into a single OGG/Opus voice file.
+```
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/tts/encoder.py tests/services/tts/test_encoder.py docs/setup.md
+git commit -m "feat(tts): add OpusEncoder (WAV chunks → OGG/Opus via ffmpeg)"
+```
+
+---
+
+## Task 4: `AttachmentTTSSink` — buffer + flush
+
+**Files:**
+- Create: `src/nanobot_runtime/services/tts/attachment_sink.py`
+- Test: `tests/services/tts/test_attachment_sink.py`
+
+### Design notes
+- Buffers `(sequence, audio_bytes)` per session_key. `audio_base64` of `None` (synth failure) is dropped from the buffer with a warning so a single failed sentence doesn't corrupt the whole turn.
+- `is_enabled(session_key)` returns True iff the channel mode is ATTACHMENT for the channel encoded in `session_key` ("<channel>:<chat_id>" prefix).
+- On `on_session_end`: pops the buffer, sorts by sequence (defensive — should already be in order), encodes via `OpusEncoder`, writes the OGG to a temp file under the workspace `media_dir` (per nanobot's `get_media_dir(channel_name)` helper), then enqueues an `OutboundMessage(channel=..., chat_id=..., content="", media=[path])` on the bus.
+- The empty `content=""` is intentional: text was already streamed during the turn via the channel's normal `send_delta` path. The voice file is a *separate* outbound; nanobot's `ChannelManager._send_with_retry` calls `channel.send(msg)` because the message has no `_stream_delta` / `_stream_end` markers, and `TelegramChannel.send` (telegram.py:478) iterates `msg.media` and dispatches `.ogg` files via `bot.send_voice`.
+
+- [ ] **Step 4.1: Write the failing test**
+
+Create `tests/services/tts/test_attachment_sink.py`:
+
+```python
+import asyncio
+from typing import Any
+
+import pytest
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+
+from nanobot_runtime.services.hooks.tts import TTSChunk
+from nanobot_runtime.services.tts.attachment_sink import AttachmentTTSSink
+from nanobot_runtime.services.tts.encoder import VoiceEncoder
+from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+
+
+class _FakeEncoder(VoiceEncoder):
+    """Stand-in for OpusEncoder — records inputs, returns canned bytes.
+
+    Inherits from `VoiceEncoder` ABC so the fake satisfies the same
+    contract as the production encoder. Forgetting `encode_wav_chunks`
+    fails at construction time.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[bytes]] = []
+        self.return_value: bytes = b"OggS-fake-opus-payload"
+
+    async def encode_wav_chunks(self, chunks: list[bytes]) -> bytes:
+        self.calls.append(list(chunks))
+        return self.return_value
+
+
+@pytest.fixture
+def mode_map_telegram_attachment() -> ChannelModeMap:
+    return ChannelModeMap(
+        default=TTSMode.NONE,
+        channels={"telegram": TTSMode.ATTACHMENT, "desktop_mate": TTSMode.STREAMING},
+    )
+
+
+@pytest.fixture
+def sink(
+    tmp_path, mode_map_telegram_attachment: ChannelModeMap
+) -> tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]:
+    bus = MessageBus()
+    encoder = _FakeEncoder()
+    s = AttachmentTTSSink(
+        mode_map=mode_map_telegram_attachment,
+        bus=bus,
+        encoder=encoder,
+        media_dir=tmp_path,
+    )
+    return s, bus, encoder
+
+
+def _wav(seq: int) -> str:
+    """Stand-in base64 audio for testing — content irrelevant to sink logic."""
+    import base64
+    return base64.b64encode(f"WAV-{seq}".encode()).decode()
+
+
+class TestAttachmentTTSSinkEnabled:
+    def test_is_enabled_true_for_attachment_channel(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, _, _ = sink
+        assert s.is_enabled("telegram:42") is True
+
+    def test_is_enabled_false_for_streaming_channel(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, _, _ = sink
+        assert s.is_enabled("desktop_mate:abc") is False
+
+    def test_is_enabled_false_for_unknown_channel(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, _, _ = sink
+        assert s.is_enabled("slack:C123") is False
+
+    def test_is_enabled_false_for_none_session_key(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, _, _ = sink
+        assert s.is_enabled(None) is False
+
+
+class TestAttachmentTTSSinkFlush:
+    @pytest.mark.asyncio
+    async def test_flush_concatenates_chunks_and_publishes_outbound(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, bus, encoder = sink
+        await s.send_tts_chunk(TTSChunk(sequence=0, text="hi", audio_base64=_wav(0), emotion=None, keyframes=[]))
+        await s.send_tts_chunk(TTSChunk(sequence=1, text="there", audio_base64=_wav(1), emotion=None, keyframes=[]))
+        await s.on_session_end("telegram:42")
+
+        assert len(encoder.calls) == 1
+        assert len(encoder.calls[0]) == 2  # both chunks fed to encoder
+
+        msg: OutboundMessage = bus.outbound.get_nowait()
+        assert msg.channel == "telegram"
+        assert msg.chat_id == "42"
+        assert msg.content == ""
+        assert len(msg.media) == 1
+        assert msg.media[0].endswith(".ogg")
+        # File must actually exist for ChannelManager to read it.
+        from pathlib import Path
+        assert Path(msg.media[0]).exists()
+
+    @pytest.mark.asyncio
+    async def test_flush_drops_failed_synth_chunks(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, _, encoder = sink
+        await s.send_tts_chunk(TTSChunk(sequence=0, text="ok", audio_base64=_wav(0), emotion=None, keyframes=[]))
+        await s.send_tts_chunk(TTSChunk(sequence=1, text="fail", audio_base64=None, emotion=None, keyframes=[]))
+        await s.send_tts_chunk(TTSChunk(sequence=2, text="ok", audio_base64=_wav(2), emotion=None, keyframes=[]))
+        await s.on_session_end("telegram:42")
+        assert len(encoder.calls[0]) == 2  # the None one was dropped
+
+    @pytest.mark.asyncio
+    async def test_flush_with_no_buffered_chunks_does_not_publish(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, bus, encoder = sink
+        await s.on_session_end("telegram:42")
+        assert encoder.calls == []
+        assert bus.outbound.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_chunks_for_disabled_session_are_ignored(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, bus, encoder = sink
+        # send_tts_chunk gets called with the session embedded in the chunk?
+        # No — TTSChunk has no session_key. The hook only calls send_tts_chunk
+        # after is_enabled() returned True. So the sink trusts the hook.
+        # This test instead verifies that on_session_end for a session whose
+        # buffer is empty (because is_enabled gated dispatch) is a no-op.
+        await s.on_session_end("slack:C123")
+        assert encoder.calls == []
+        assert bus.outbound.qsize() == 0
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_sessions_have_independent_buffers(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, bus, encoder = sink
+        # Simulate interleaved chunks from two telegram chats.
+        # The sink doesn't see session_key per chunk — it sees on_session_end
+        # per session. So we test that flushing one session does NOT drain
+        # the other. To do this we need the sink to associate buffered
+        # chunks with their session. Implementation note: the sink must
+        # therefore receive a session_key on send_tts_chunk OR maintain a
+        # single "current session" — see implementation choice in 4.2.
+        pytest.skip("Covered by implementation-choice decision; see Task 4.2")
+```
+
+- [ ] **Step 4.2: Run test to verify it fails AND resolve the per-session buffering question**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_attachment_sink.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+**Implementation choice (resolved here, locked in for Step 4.3):** `TTSChunk` has no `session_key` field, so the sink cannot associate an incoming chunk to a session from the chunk alone. There are two options:
+
+- **A. Add `session_key: str | None` to `TTSChunk`** and have `TTSHook._dispatch_sentence` populate it. Cleanest, but touches the hook contract and the streaming sink (which currently ignores it).
+- **B. Sink maintains a "current session" set by `is_enabled` returning True.** Hacky — `is_enabled` is a pure check and shouldn't have side effects.
+
+**Decision: A.** The change to `TTSChunk` is additive (`Field(default=None)`), so DesktopMate streaming sink and existing tests are unaffected. We add this in Task 4 alongside the sink itself.
+
+- [ ] **Step 4.3: Add `session_key` to `TTSChunk` and populate in TTSHook**
+
+Edit `src/nanobot_runtime/services/hooks/tts.py`:
+
+In `TTSChunk`, add the field:
+
+```python
+class TTSChunk(BaseModel):
+    """Data emitted to the TTS sink per completed sentence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sequence: int = Field(description="Zero-based index of this chunk within the current stream.")
+    text: str = Field(description="Cleaned sentence text sent to the TTS engine.")
+    audio_base64: str | None = Field(description="Base64-encoded WAV audio, or None on failure.")
+    emotion: str | None = Field(description="Detected emotion emoji/tag, or None.")
+    keyframes: list[dict[str, Any]] = Field(
+        default_factory=list, description="Animation keyframe dicts for the emotion."
+    )
+    session_key: str | None = Field(
+        default=None,
+        description="Session this chunk belongs to (for multi-session sinks). None for legacy callers.",
+    )
+```
+
+In `TTSHook._synth_and_emit`, when constructing the chunk, pass the session_key:
+
+```python
+        chunk = TTSChunk(
+            sequence=sequence,
+            text=text,
+            audio_base64=audio_b64,
+            emotion=emotion,
+            keyframes=keyframes,
+            session_key=session_key,
+        )
+```
+
+(`session_key` is already a parameter to `_synth_and_emit` so no other plumbing is needed.)
+
+- [ ] **Step 4.4: Implement `AttachmentTTSSink`**
+
+Create `src/nanobot_runtime/services/tts/attachment_sink.py`:
+
+```python
+"""Buffer-and-flush TTS sink for ATTACHMENT-mode channels.
+
+Per-session buffer of synthesized WAV chunks, flushed on ``on_session_end``
+into a single OGG/Opus voice file enqueued onto the message bus.
+
+The sink is the ATTACHMENT-mode analogue of ``LazyChannelTTSSink``:
+- ``LazyChannelTTSSink`` pushes per-sentence frames live to DesktopMate.
+- ``AttachmentTTSSink`` collects, encodes, and emits one voice-note per turn.
+
+Both are routed by ``MultiplexingTTSSink`` based on ``ChannelModeMap``.
+"""
+import base64
+import time
+import uuid
+from pathlib import Path
+
+from loguru import logger
+from nanobot.bus.events import OutboundMessage
+from nanobot.bus.queue import MessageBus
+
+from nanobot_runtime.services.hooks.tts import TTSChunk, TTSSink
+from nanobot_runtime.services.tts.encoder import VoiceEncoder
+from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+
+
+class AttachmentTTSSink(TTSSink):
+    """Collect TTSChunks per session, flush as a single OGG/Opus voice-note."""
+
+    def __init__(
+        self,
+        *,
+        mode_map: ChannelModeMap,
+        bus: MessageBus,
+        encoder: VoiceEncoder,
+        media_dir: Path,
+    ) -> None:
+        self._mode_map: ChannelModeMap = mode_map
+        self._bus: MessageBus = bus
+        self._encoder: VoiceEncoder = encoder
+        self._media_dir: Path = media_dir
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+        # session_key -> list[(sequence, wav_bytes)]
+        self._buffers: dict[str, list[tuple[int, bytes]]] = {}
+
+    # ── Sink contract ───────────────────────────────────────────────────
+
+    def is_enabled(self, session_key: str | None) -> bool:
+        channel = self._channel_from_session_key(session_key)
+        return self._mode_map.lookup(channel) is TTSMode.ATTACHMENT
+
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
+        if chunk.session_key is None:
+            logger.warning(
+                "AttachmentTTSSink: chunk seq={} has no session_key; dropping",
+                chunk.sequence,
+            )
+            return
+        if chunk.audio_base64 is None:
+            logger.warning(
+                "AttachmentTTSSink: chunk seq={} has no audio (synth failed); dropping",
+                chunk.sequence,
+            )
+            return
+        try:
+            wav = base64.b64decode(chunk.audio_base64)
+        except Exception:
+            logger.exception(
+                "AttachmentTTSSink: chunk seq={} audio_base64 decode failed; dropping",
+                chunk.sequence,
+            )
+            return
+        self._buffers.setdefault(chunk.session_key, []).append((chunk.sequence, wav))
+
+    async def on_session_end(self, session_key: str | None) -> None:
+        if session_key is None:
+            return
+        buffered = self._buffers.pop(session_key, None)
+        if not buffered:
+            return
+        # Sort defensively — TTSHook dispatches in order but synth tasks
+        # complete out-of-order, and the sink receives them in completion
+        # order. Sequence numbers restore audio order.
+        buffered.sort(key=lambda pair: pair[0])
+        wav_chunks = [wav for _, wav in buffered]
+        try:
+            opus_bytes = await self._encoder.encode_wav_chunks(wav_chunks)
+        except Exception:
+            logger.exception(
+                "AttachmentTTSSink: encoder failed for session={}; dropping {} chunks",
+                session_key, len(wav_chunks),
+            )
+            return
+        channel = self._channel_from_session_key(session_key)
+        chat_id = self._chat_id_from_session_key(session_key)
+        if channel is None or chat_id is None:
+            logger.warning(
+                "AttachmentTTSSink: malformed session_key={}; dropping voice", session_key
+            )
+            return
+        out_path = self._write_voice_file(channel, chat_id, opus_bytes)
+        await self._bus.publish_outbound(
+            OutboundMessage(
+                channel=channel,
+                chat_id=chat_id,
+                content="",
+                media=[str(out_path)],
+                metadata={"_tts_attachment": True},
+            )
+        )
+        logger.info(
+            "🔊 TTS attachment dispatched: channel={} chat_id={} chunks={} bytes={}",
+            channel, chat_id, len(wav_chunks), len(opus_bytes),
+        )
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _channel_from_session_key(session_key: str | None) -> str | None:
+        if not session_key:
+            return None
+        prefix, sep, _ = session_key.partition(":")
+        return prefix if sep else None
+
+    @staticmethod
+    def _chat_id_from_session_key(session_key: str | None) -> str | None:
+        if not session_key:
+            return None
+        _, sep, rest = session_key.partition(":")
+        if not sep or not rest:
+            return None
+        # nanobot uses "<channel>:<chat_id>[:<thread>...]". For ATTACHMENT
+        # mode (text channels), chat_id is the second segment.
+        chat_id, _, _ = rest.partition(":")
+        return chat_id or None
+
+    def _write_voice_file(self, channel: str, chat_id: str, opus_bytes: bytes) -> Path:
+        ts = int(time.time() * 1000)
+        name = f"{channel}_{chat_id}_{ts}_{uuid.uuid4().hex[:8]}.ogg"
+        out = self._media_dir / name
+        out.write_bytes(opus_bytes)
+        return out
+```
+
+- [ ] **Step 4.5: Un-skip the concurrent-sessions test**
+
+Now that `session_key` is on `TTSChunk` and the sink keys buffers by it, replace the `pytest.skip` in `test_two_concurrent_sessions_have_independent_buffers` with a real assertion:
+
+```python
+    @pytest.mark.asyncio
+    async def test_two_concurrent_sessions_have_independent_buffers(
+        self, sink: tuple[AttachmentTTSSink, MessageBus, _FakeEncoder]
+    ) -> None:
+        s, bus, encoder = sink
+        await s.send_tts_chunk(TTSChunk(sequence=0, text="a", audio_base64=_wav(0), emotion=None, keyframes=[], session_key="telegram:1"))
+        await s.send_tts_chunk(TTSChunk(sequence=0, text="b", audio_base64=_wav(0), emotion=None, keyframes=[], session_key="telegram:2"))
+        await s.send_tts_chunk(TTSChunk(sequence=1, text="c", audio_base64=_wav(1), emotion=None, keyframes=[], session_key="telegram:1"))
+
+        await s.on_session_end("telegram:1")
+        # Only chat 1's buffer flushed
+        assert len(encoder.calls) == 1
+        assert len(encoder.calls[0]) == 2
+        msg1 = bus.outbound.get_nowait()
+        assert msg1.chat_id == "1"
+
+        await s.on_session_end("telegram:2")
+        assert len(encoder.calls) == 2
+        assert len(encoder.calls[1]) == 1
+        msg2 = bus.outbound.get_nowait()
+        assert msg2.chat_id == "2"
+```
+
+Also update the existing `test_flush_concatenates_chunks_and_publishes_outbound` and `test_flush_drops_failed_synth_chunks` tests to pass `session_key="telegram:42"` on each `TTSChunk(...)` constructor call.
+
+- [ ] **Step 4.6: Run all sink tests**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_attachment_sink.py -v`
+Expected: ALL PASSED.
+
+- [ ] **Step 4.7: Run hook tests for regression (TTSChunk shape change)**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/hooks/ tests/services/tts/ tests/services/channels/ -v`
+Expected: ALL PASSED. If any test breaks because it constructed `TTSChunk(...)` without `session_key`, that's fine — the field defaults to `None` so callers don't need updating, but if a strict equality test fails, update the expected value.
+
+- [ ] **Step 4.8: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/hooks/tts.py src/nanobot_runtime/services/tts/attachment_sink.py tests/services/tts/test_attachment_sink.py
+git commit -m "feat(tts): AttachmentTTSSink — buffer per-session, flush as OGG/Opus voice-note"
+```
+
+---
+
+## Task 5: `MultiplexingTTSSink` — route per-chunk by mode
+
+**Files:**
+- Create: `src/nanobot_runtime/services/tts/multiplex_sink.py`
+- Test: `tests/services/tts/test_multiplex_sink.py`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `tests/services/tts/test_multiplex_sink.py`:
+
+```python
+import pytest
+
+from nanobot_runtime.services.hooks.tts import TTSChunk, TTSSink
+from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+from nanobot_runtime.services.tts.multiplex_sink import MultiplexingTTSSink
+
+
+class _RecordingSink(TTSSink):
+    def __init__(self, name: str, enabled_for: set[str | None]) -> None:
+        self.name = name
+        self._enabled_for = enabled_for
+        self.chunks: list[TTSChunk] = []
+        self.session_ends: list[str | None] = []
+
+    def is_enabled(self, session_key: str | None) -> bool:
+        return session_key in self._enabled_for
+
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
+        self.chunks.append(chunk)
+
+    async def on_session_end(self, session_key: str | None) -> None:
+        self.session_ends.append(session_key)
+
+
+@pytest.fixture
+def sinks() -> tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]:
+    streaming = _RecordingSink("streaming", {"desktop_mate:abc"})
+    attachment = _RecordingSink("attachment", {"telegram:42"})
+    mode_map = ChannelModeMap(
+        default=TTSMode.NONE,
+        channels={"desktop_mate": TTSMode.STREAMING, "telegram": TTSMode.ATTACHMENT},
+    )
+    mux = MultiplexingTTSSink(
+        mode_map=mode_map,
+        streaming_sink=streaming,
+        attachment_sink=attachment,
+    )
+    return streaming, attachment, mux
+
+
+class TestMultiplexingTTSSink:
+    def test_is_enabled_routes_streaming_to_streaming_sink(
+        self, sinks: tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]
+    ) -> None:
+        _, _, mux = sinks
+        assert mux.is_enabled("desktop_mate:abc") is True
+
+    def test_is_enabled_routes_attachment_to_attachment_sink(
+        self, sinks: tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]
+    ) -> None:
+        _, _, mux = sinks
+        assert mux.is_enabled("telegram:42") is True
+
+    def test_is_enabled_false_for_none_mode_channel(
+        self, sinks: tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]
+    ) -> None:
+        _, _, mux = sinks
+        assert mux.is_enabled("slack:C123") is False
+
+    @pytest.mark.asyncio
+    async def test_send_tts_chunk_routes_by_chunk_session_key(
+        self, sinks: tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]
+    ) -> None:
+        streaming, attachment, mux = sinks
+        await mux.send_tts_chunk(
+            TTSChunk(sequence=0, text="dm", audio_base64="A", emotion=None, keyframes=[], session_key="desktop_mate:abc")
+        )
+        await mux.send_tts_chunk(
+            TTSChunk(sequence=0, text="tg", audio_base64="A", emotion=None, keyframes=[], session_key="telegram:42")
+        )
+        assert [c.text for c in streaming.chunks] == ["dm"]
+        assert [c.text for c in attachment.chunks] == ["tg"]
+
+    @pytest.mark.asyncio
+    async def test_on_session_end_fans_out_to_both(
+        self, sinks: tuple[_RecordingSink, _RecordingSink, MultiplexingTTSSink]
+    ) -> None:
+        streaming, attachment, mux = sinks
+        # Fan-out is the simple choice: each child decides whether it cares.
+        # Streaming sink ignores; attachment sink flushes its buffer.
+        await mux.on_session_end("telegram:42")
+        assert streaming.session_ends == ["telegram:42"]
+        assert attachment.session_ends == ["telegram:42"]
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_multiplex_sink.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 5.3: Implement the multiplexer**
+
+Create `src/nanobot_runtime/services/tts/multiplex_sink.py`:
+
+```python
+"""Mode-based router that fans TTSChunks to either streaming or attachment sink.
+
+The multiplexer is the single sink injected into ``TTSHook``. Per call:
+
+- ``is_enabled(session_key)``: returns the OR of the two child sinks' verdicts
+  for that session, gated by the channel's mode in ``ChannelModeMap``.
+- ``send_tts_chunk(chunk)``: routes by the chunk's own ``session_key`` field
+  (populated by ``TTSHook``) — STREAMING channels go to the streaming sink,
+  ATTACHMENT channels to the attachment sink.
+- ``on_session_end(session_key)``: fans out to BOTH children. Each decides
+  whether to act based on its own buffer state. The streaming sink's
+  ``on_session_end`` is a no-op; the attachment sink uses it as the flush
+  trigger. Fan-out is intentional — neither sink need know about the other,
+  and per-channel routing is settled in the mode map alone.
+"""
+from loguru import logger
+
+from nanobot_runtime.services.hooks.tts import TTSChunk, TTSSink
+from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+
+
+class MultiplexingTTSSink(TTSSink):
+    """Fan TTSChunks to STREAMING or ATTACHMENT sink based on channel mode."""
+
+    def __init__(
+        self,
+        *,
+        mode_map: ChannelModeMap,
+        streaming_sink: TTSSink,
+        attachment_sink: TTSSink,
+    ) -> None:
+        self._mode_map: ChannelModeMap = mode_map
+        self._streaming: TTSSink = streaming_sink
+        self._attachment: TTSSink = attachment_sink
+
+    def is_enabled(self, session_key: str | None) -> bool:
+        mode = self._mode_map.lookup(self._channel_from_session_key(session_key))
+        if mode is TTSMode.STREAMING:
+            return self._streaming.is_enabled(session_key)
+        if mode is TTSMode.ATTACHMENT:
+            return self._attachment.is_enabled(session_key)
+        return False
+
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None:
+        mode = self._mode_map.lookup(self._channel_from_session_key(chunk.session_key))
+        if mode is TTSMode.STREAMING:
+            await self._streaming.send_tts_chunk(chunk)
+        elif mode is TTSMode.ATTACHMENT:
+            await self._attachment.send_tts_chunk(chunk)
+        else:
+            logger.warning(
+                "MultiplexingTTSSink: chunk seq={} has session_key={} with mode={}; dropping",
+                chunk.sequence, chunk.session_key, mode,
+            )
+
+    async def on_session_end(self, session_key: str | None) -> None:
+        # Fan-out: both children get the notification. Cheap (each is a
+        # method call), and avoids asking the multiplexer to remember which
+        # child handled which session.
+        await self._streaming.on_session_end(session_key)
+        await self._attachment.on_session_end(session_key)
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _channel_from_session_key(session_key: str | None) -> str | None:
+        if not session_key:
+            return None
+        prefix, sep, _ = session_key.partition(":")
+        return prefix if sep else None
+```
+
+- [ ] **Step 5.4: Run tests**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_multiplex_sink.py -v`
+Expected: 5 PASSED.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/tts/multiplex_sink.py tests/services/tts/test_multiplex_sink.py
+git commit -m "feat(tts): MultiplexingTTSSink — route chunks by channel mode"
+```
+
+---
+
+## Task 6: Wire the multiplexer into the launcher
+
+**Files:**
+- Modify: `src/nanobot_runtime/launcher.py:60-101` (the `_build_tts_hook` function)
+- Modify: `tests/services/channels/test_tts_sink_wiring.py` (existing test must pass with the new shape)
+
+- [ ] **Step 6.1: Read the existing wiring test to know what must keep passing**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && cat tests/services/channels/test_tts_sink_wiring.py`
+
+Identify the assertions about sink type. If the test asserts the sink is a `LazyChannelTTSSink`, change to assert it's a `MultiplexingTTSSink` whose streaming child is a `LazyChannelTTSSink`. Make this update minimally — don't rewrite the test.
+
+- [ ] **Step 6.2: Add a focused new wiring test for the multiplexer**
+
+In `tests/services/channels/test_tts_sink_wiring.py` (or a new co-located test file `test_tts_attachment_wiring.py` if the existing file is overloaded), add:
+
+```python
+class TestAttachmentSinkWiring:
+    def test_launcher_wires_multiplexer_with_attachment_sink_for_telegram(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """The hook's sink must be a MultiplexingTTSSink whose attachment
+        child reports is_enabled=True for telegram session keys."""
+        from nanobot_runtime.launcher import _build_tts_hook
+        from nanobot_runtime.services.tts.multiplex_sink import MultiplexingTTSSink
+
+        # Set up minimal env + workspace dirs
+        rules = tmp_path / "rules.yml"
+        rules.write_text("emotions: {}\n")
+        modes = tmp_path / "modes.yml"
+        modes.write_text(
+            "default: none\nchannels:\n  desktop_mate: streaming\n  telegram: attachment\n"
+        )
+        monkeypatch.setenv("TTS_RULES_PATH", str(rules))
+        monkeypatch.setenv("TTS_MODES_PATH", str(modes))
+        monkeypatch.setenv("TTS_URL", "http://stub")
+
+        hook = _build_tts_hook()
+        sink = hook._sink  # type: ignore[attr-defined] — test-only introspection
+        assert isinstance(sink, MultiplexingTTSSink)
+        assert sink.is_enabled("telegram:42") is True
+        assert sink.is_enabled("desktop_mate:abc") is True
+        assert sink.is_enabled("slack:C123") is False
+```
+
+- [ ] **Step 6.3: Run the test — expect it to fail because the launcher still wires only LazyChannelTTSSink**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/channels/test_tts_sink_wiring.py -v`
+Expected: FAIL on the new test (existing tests may also fail if they introspected the sink type).
+
+- [ ] **Step 6.4: Update `_build_tts_hook` to produce a MultiplexingTTSSink**
+
+Edit `src/nanobot_runtime/launcher.py`. Add imports near the existing TTS imports:
+
+```python
+from nanobot.bus.queue import MessageBus
+from nanobot.config.paths import get_media_dir
+
+from nanobot_runtime.services.tts.attachment_sink import AttachmentTTSSink
+from nanobot_runtime.services.tts.encoder import OpusEncoder
+from nanobot_runtime.services.tts.multiplex_sink import MultiplexingTTSSink
+```
+
+Change the function signature and body. The current `_build_tts_hook()` takes no args and constructs a sink that doesn't need a bus. The attachment sink needs a bus, so the function now takes the bus as a parameter:
+
+```python
+def _build_tts_hook(bus: MessageBus) -> TTSHook:
+    """Assemble the TTS pipeline.
+
+    Composition:
+      MultiplexingTTSSink
+        ├── streaming → LazyChannelTTSSink (DesktopMate)
+        └── attachment → AttachmentTTSSink (Telegram, ...)
+
+    The attachment sink encodes per-turn voice-notes via :class:`OpusEncoder`
+    and publishes them onto ``bus`` for the channel manager to dispatch.
+    """
+    rules_path = _resolve_tts_rules_path()
+    if not os.path.exists(rules_path):
+        raise FileNotFoundError(
+            f"TTS rules YAML not found at {rules_path!r}. Set "
+            "TTS_RULES_PATH or place the file at "
+            "<workspace>/resources/tts_rules.yml. To run without TTS set "
+            "TTS_ENABLED=0."
+        )
+    modes_path = _resolve_tts_modes_path()
+    if not os.path.exists(modes_path):
+        raise FileNotFoundError(
+            f"TTS channel modes YAML not found at {modes_path!r}. Set "
+            "TTS_MODES_PATH or place the file at "
+            "<workspace>/resources/tts_channel_modes.yml. To run without TTS set "
+            "TTS_ENABLED=0."
+        )
+    mode_map = load_channel_modes(modes_path)
+    emotion_mapper = EmotionMapper.from_yaml(rules_path)
+    synthesizer = IrodoriClient(
+        base_url=os.getenv("TTS_URL", "http://192.168.0.41:8091"),
+        reference_id=os.getenv("TTS_REF_AUDIO"),
+    )
+
+    streaming_sink = LazyChannelTTSSink(mode_map=mode_map)
+    attachment_sink = AttachmentTTSSink(
+        mode_map=mode_map,
+        bus=bus,
+        encoder=OpusEncoder(),
+        media_dir=get_media_dir("tts_attachments"),
+    )
+    sink = MultiplexingTTSSink(
+        mode_map=mode_map,
+        streaming_sink=streaming_sink,
+        attachment_sink=attachment_sink,
+    )
+    return TTSHook(
+        chunker_factory=SentenceChunker,
+        preprocessor=Preprocessor(known_emojis=emotion_mapper.known_emojis),
+        emotion_mapper=emotion_mapper,
+        synthesizer=synthesizer,
+        sink=sink,
+        barrier_timeout_seconds=float(os.getenv("TTS_BARRIER_TIMEOUT", "30")),
+    )
+```
+
+Update the caller of `_build_tts_hook` (search the file for it). It will need to pass the bus that the gateway constructs. If the bus is constructed inside `gateway.run()`, you'll need to thread it back — read `gateway.py` to find the right injection point. The simplest correct fix is to expose a builder hook on `gateway.run()` that takes a `bus -> AgentHook` factory.
+
+If that's too invasive, an acceptable alternative is to construct the bus in the launcher first, pass it to both the TTS hook builder AND the gateway. Choose whichever is smaller in diff size.
+
+- [ ] **Step 6.5: Update the new test fixture to pass the bus**
+
+Edit the test from Step 6.2 to construct a bus and pass it:
+
+```python
+        from nanobot.bus.queue import MessageBus
+        bus = MessageBus()
+        hook = _build_tts_hook(bus)
+```
+
+- [ ] **Step 6.6: Run the tests**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/channels/test_tts_sink_wiring.py tests/test_launcher.py -v`
+Expected: ALL PASSED.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/launcher.py src/nanobot_runtime/gateway.py tests/services/channels/test_tts_sink_wiring.py
+git commit -m "feat(tts): wire MultiplexingTTSSink + AttachmentTTSSink in launcher"
+```
+
+---
+
+## Task 7: Remove the "ATTACHMENT pipeline TBD" warning
+
+**Files:**
+- Modify: `src/nanobot_runtime/services/tts/modes.py:122-137`
+- Modify: `tests/services/tts/test_modes.py` (drop or update the test that asserts the warning fires)
+
+- [ ] **Step 7.1: Find the existing warning test**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && grep -n "TBD\|attachment" tests/services/tts/test_modes.py`
+
+Note the test name(s) that check the warning behavior.
+
+- [ ] **Step 7.2: Update modes.py**
+
+Edit `src/nanobot_runtime/services/tts/modes.py`. Replace the `attachment_channels` warning block (lines 122-137) with:
+
+```python
+    if attachment_channels := sorted(
+        name for name, mode in result.channels.items() if mode is TTSMode.ATTACHMENT
+    ):
+        logger.info(
+            "🎙️ TTS ATTACHMENT mode active for channels: {}", attachment_channels
+        )
+    return result
+```
+
+(The walrus is intentional: same logic, no warning, just an info-level lifecycle marker per the CODING_RULES emoji-marker convention.)
+
+- [ ] **Step 7.3: Update the test**
+
+Replace the warning-expectation test with one that asserts the info log fires. If the test was using `caplog`, just change the expected level and message. If it was a structural "ATTACHMENT silently NONE" test, delete it — the assumption is no longer true.
+
+- [ ] **Step 7.4: Run modes tests**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_modes.py -v`
+Expected: ALL PASSED.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add src/nanobot_runtime/services/tts/modes.py tests/services/tts/test_modes.py
+git commit -m "feat(tts): drop ATTACHMENT-pipeline-TBD warning; replaced with lifecycle info log"
+```
+
+---
+
+## Task 8: Integration test — TTSHook → Multiplexer → AttachmentTTSSink → bus
+
+**Files:**
+- Create: `tests/services/tts/test_attachment_integration.py`
+
+- [ ] **Step 8.1: Write the integration test**
+
+Create `tests/services/tts/test_attachment_integration.py`:
+
+```python
+import asyncio
+import base64
+import wave
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from nanobot.agent.hook import AgentHookContext
+from nanobot.bus.queue import MessageBus
+
+from nanobot_runtime.services.channels.desktop_mate import LazyChannelTTSSink
+from nanobot_runtime.services.hooks.tts import TTSHook
+from nanobot_runtime.services.tts.attachment_sink import AttachmentTTSSink
+from nanobot_runtime.services.tts.encoder import OpusEncoder
+from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
+from nanobot_runtime.services.tts.multiplex_sink import MultiplexingTTSSink
+
+
+def _wav_b64() -> str:
+    buf = BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16_000)
+        w.writeframes(b"\x00\x00" * 1600)  # 0.1s silence
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+class _StubChunker:
+    def feed(self, delta: str) -> list[str]:
+        return [delta] if delta.endswith(".") else []
+
+    def flush(self) -> str | None:
+        return None
+
+
+class _StubPreprocessor:
+    def process(self, sentence: str) -> tuple[str, str | None]:
+        return sentence, None
+
+
+class _StubEmotionMapper:
+    def map(self, emotion):
+        return []
+
+
+class _StubSynth:
+    async def synthesize(self, text: str, *, reference_id=None) -> str:
+        return _wav_b64()
+
+
+@pytest.mark.asyncio
+async def test_full_attachment_pipeline_emits_voice_outbound(tmp_path: Path) -> None:
+    """End-to-end: hook receives deltas, dispatches to multiplexer, attachment
+    sink buffers, on_stream_end barrier fires, encoder produces OGG, bus has
+    one OutboundMessage with .ogg media for the telegram channel."""
+    import shutil
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg required for end-to-end encoding")
+
+    bus = MessageBus()
+    mode_map = ChannelModeMap(
+        default=TTSMode.NONE,
+        channels={"telegram": TTSMode.ATTACHMENT, "desktop_mate": TTSMode.STREAMING},
+    )
+    streaming = LazyChannelTTSSink(mode_map=mode_map)
+    attachment = AttachmentTTSSink(
+        mode_map=mode_map, bus=bus, encoder=OpusEncoder(), media_dir=tmp_path
+    )
+    mux = MultiplexingTTSSink(
+        mode_map=mode_map, streaming_sink=streaming, attachment_sink=attachment
+    )
+    hook = TTSHook(
+        chunker_factory=_StubChunker,
+        preprocessor=_StubPreprocessor(),
+        emotion_mapper=_StubEmotionMapper(),
+        synthesizer=_StubSynth(),
+        sink=mux,
+        barrier_timeout_seconds=5.0,
+    )
+
+    ctx = AgentHookContext(session_key="telegram:42")
+    await hook.on_stream(ctx, "hello.")
+    await hook.on_stream(ctx, "there.")
+    await hook.on_stream_end(ctx, resuming=False)
+
+    assert bus.outbound.qsize() == 1
+    msg = bus.outbound.get_nowait()
+    assert msg.channel == "telegram"
+    assert msg.chat_id == "42"
+    assert len(msg.media) == 1
+    out_path = Path(msg.media[0])
+    assert out_path.exists()
+    assert out_path.suffix == ".ogg"
+    assert out_path.read_bytes().startswith(b"OggS")
+```
+
+- [ ] **Step 8.2: Run it**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/test_attachment_integration.py -v`
+Expected: 1 PASSED.
+
+- [ ] **Step 8.3: Run the full TTS-related test suite as a regression sweep**
+
+Run: `cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime && uv run pytest tests/services/tts/ tests/services/hooks/ tests/services/channels/ -v`
+Expected: ALL PASSED.
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git add tests/services/tts/test_attachment_integration.py
+git commit -m "test(tts): end-to-end attachment pipeline integration test"
+```
+
+---
+
+## Task 9: Live e2e on the workspace
+
+This is a manual verification step the engineer performs once code merges. It does NOT block the PR but does block declaring the work shipped.
+
+**Pre-reqs (NOT done in this plan — user-action items):**
+- BotFather token obtained.
+- `TELEGRAM_BOT_TOKEN` env var set in the yuri runtime environment.
+- `yuri/nanobot.json` has the `telegram` channel block enabled (Phase 1-3 from the conversation that produced this plan).
+- `yuri/resources/tts_channel_modes.yml` already has `telegram: attachment` (already in place pre-plan).
+
+- [ ] **Step 9.1: Restart yuri runtime**
+
+Run whatever command starts yuri in the dev environment.
+
+Tail logs and confirm no `FileNotFoundError`, no `TTS rules YAML not found`, and the new info log `🎙️ TTS ATTACHMENT mode active for channels: ['telegram']` is present.
+
+- [ ] **Step 9.2: Send a text message to the bot from a Telegram client (PC or mobile, both should work)**
+
+Expected behavior:
+1. Bot streams text response (existing behavior).
+2. Within ~1-2 seconds of stream end, a voice-note appears in the chat with waveform UI.
+3. Voice-note is mono OGG/Opus, plays back the same content as the text.
+
+- [ ] **Step 9.3: Send a message that triggers a tool call (e.g. a memory lookup if LTM is wired)**
+
+Expected behavior: the tool call hop does NOT produce a partial voice-note. Only the final terminal stream_end produces one voice-note covering the whole turn. (This is the `resuming=False` gate from Task 1.)
+
+- [ ] **Step 9.4: Verify DesktopMate streaming was not regressed**
+
+Open the DesktopMate FE, send a message → audio chunks arrive in real time as before. No double audio.
+
+- [ ] **Step 9.5: Open the PR**
+
+```bash
+cd /home/spow12/codes/2026_upper/agents/yuri/nanobot_runtime
+git push -u origin <feat-branch-name>
+gh pr create --base develop --title "feat(tts): ATTACHMENT pipeline for Telegram voice-notes" --body "<summary + test plan>"
+```
+
+---
+
+## Self-Review Checklist (run before handing off)
+
+**Spec coverage:**
+- [x] `on_session_end` notification on TTSSink (Task 1)
+- [x] WAV → OGG/Opus encoder (Task 3)
+- [x] Per-session buffering + flush (Task 4)
+- [x] Multiplex routing by mode (Task 5)
+- [x] Launcher wiring (Task 6)
+- [x] Drop the TBD warning (Task 7)
+- [x] Integration test (Task 8)
+- [x] Live e2e (Task 9)
+
+**Type consistency:**
+- `TTSChunk.session_key: str | None` (Task 4.3) — used by `AttachmentTTSSink.send_tts_chunk` (Task 4.4) and `MultiplexingTTSSink.send_tts_chunk` (Task 5.3). Consistent.
+- `VoiceEncoder` ABC + `OpusEncoder` concrete (Task 3.3) — referenced as `VoiceEncoder` in `AttachmentTTSSink.__init__` (Task 4.4), in test fakes that inherit from `VoiceEncoder` (Task 4.1), and in integration test usage (Task 8.1). Consistent.
+- `AttachmentTTSSink.__init__(*, mode_map, bus, encoder, media_dir)` (Task 4.4) — matches launcher construction (Task 6.4) and integration test fixture (Task 8.1). Consistent.
+
+**ABC unification (per user request):**
+- ✅ `TTSSink` ABC — `is_enabled`, `send_tts_chunk`, `on_session_end` are ALL `@abstractmethod`. Concrete subclasses (`LazyChannelTTSSink`, `AttachmentTTSSink`, `MultiplexingTTSSink`) inherit and explicitly implement each.
+- ✅ `VoiceEncoder` ABC — `encode_wav_chunks` is `@abstractmethod`. Concrete (`OpusEncoder`) and test fakes (`_FakeEncoder`) both inherit.
+- ⚠️ Existing `SentenceChunker` / `TextPreprocessor` / `EmotionMapper` / `TTSSynthesizer` remain `typing.Protocol` — out of scope for this PR. Conversion requires touching `IrodoriClient`, `Preprocessor`, `EmotionMapper`, `SentenceChunker` simultaneously plus all their tests. Tracked as a follow-up refactor.
+
+**Placeholder scan:** None — all code blocks are complete; no "TODO" / "TBD" / "implement later" tokens in the plan body.
+
+**Risks / open questions for the engineer:**
+1. **Bus injection in launcher (Task 6.4)** — the smallest correct fix depends on how `gateway.run()` is structured. Read `gateway.py` first; if the bus is created inside `run()`, the cleanest path is to create it in the launcher and pass it down. Don't refactor more than needed.
+2. **`get_media_dir` import path** — verify it's `nanobot.config.paths.get_media_dir`. It was referenced in `desktop_mate.py:151` so the path is known to exist.
+3. **`AgentHookContext` constructor in tests** — verify the hook context is constructed with `session_key=` (kwarg). If nanobot's hook context is positional or uses a different field name, adjust the test stubs accordingly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
     "pytest-httpx>=0.30",
 ]
 

--- a/scripts/check_antipatterns.py
+++ b/scripts/check_antipatterns.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Detect CODING_RULES anti-patterns not caught by ruff/black."""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+_VIOLATIONS: list[tuple[str, int, str]] = []
+_SEEN: set[tuple[str, int, str]] = set()
+
+
+def _walk_shallow(nodes: list[ast.stmt]) -> list[ast.AST]:
+    """Walk AST nodes without descending into nested function/class scopes."""
+    result = []
+    for node in nodes:
+        result.append(node)
+        for child in ast.iter_child_nodes(node):
+            if not isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                result.extend(_walk_shallow([child]))
+    return result
+
+
+def _check_file(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+
+    # ── Regex check: # --- section comment style ─────────────────────────────
+    for i, line in enumerate(lines, 1):
+        if re.match(r"^#\s*-{3,}\s*$", line.strip()):
+            _VIOLATIONS.append((str(path), i, "section comment uses '# ---' style — use '# ── Name ───' unicode style"))
+
+    # ── AST checks ────────────────────────────────────────────────────────────
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return
+
+    for node in ast.walk(tree):
+        # stdlib logging import
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "logging" or alias.name.startswith("logging."):
+                    _VIOLATIONS.append((str(path), node.lineno, "stdlib 'logging' import — use loguru logger"))
+
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "logging" or module.startswith("logging."):
+                _VIOLATIONS.append((str(path), node.lineno, "stdlib 'logging' import — use loguru logger"))
+
+        # asyncio.gather(return_exceptions=True)
+        if isinstance(node, ast.Call):
+            func = node.func
+            is_gather = (
+                (isinstance(func, ast.Attribute) and func.attr == "gather")
+                or (isinstance(func, ast.Name) and func.id == "gather")
+            )
+            if is_gather:
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "return_exceptions"
+                        and isinstance(kw.value, ast.Constant)
+                        and kw.value.value is True
+                    ):
+                        _VIOLATIONS.append(
+                            (str(path), node.lineno, "asyncio.gather(return_exceptions=True) used — handle each result explicitly")
+                        )
+
+        # logger.error/warning() inside except block — traceback loss
+        if isinstance(node, ast.ExceptHandler):
+            for child in _walk_shallow(node.body):
+                if not isinstance(child, ast.Call):
+                    continue
+                func = child.func
+                if not (
+                    isinstance(func, ast.Attribute)
+                    and func.attr in ("error", "warning")
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "logger"
+                ):
+                    continue
+                if func.attr == "error":
+                    msg = "logger.error() in except block loses traceback — use logger.exception()"
+                else:
+                    msg = "logger.warning() in except block loses traceback — use logger.opt(exception=True).warning()"
+                _VIOLATIONS.append((str(path), child.lineno, msg))
+
+
+def main() -> int:
+    roots = [Path("src"), Path("tests")]
+    files: list[Path] = []
+    for root in roots:
+        if root.exists():
+            files.extend(root.rglob("*.py"))
+
+    for f in sorted(files):
+        _check_file(f)
+
+    unique = sorted(set(_VIOLATIONS))
+    if not unique:
+        print("check_antipatterns: no violations found")
+        return 0
+
+    print("check_antipatterns: violations found")
+    for path, line, msg in unique:
+        print(f"  {path}:{line}: {msg}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,7 @@
+uv run black src/ tests/
+
+# Lint code
+uv run ruff check src/ tests/ --unsafe-fixes --fix
+
+# Custom anti-pattern checks (not covered by ruff)
+uv run python scripts/check_antipatterns.py

--- a/src/nanobot_runtime/__init__.py
+++ b/src/nanobot_runtime/__init__.py
@@ -4,11 +4,12 @@ Exposes AgentLoop hooks (LTM inject/args/save), a gateway launcher that
 monkey-patches AgentLoop.__init__ to inject those hooks, and utility
 factories that wire them up from a single user_id/agent_id/ltm_url triple.
 """
+
 from nanobot_runtime.services.hooks import (
-    LTMArgumentsHook,
-    LTMInjectionHook,
-    LTMMCPClient,
-    LTMSavingConsolidator,
-    build_ltm_hooks,
-    install_ltm_saving,
+    LTMArgumentsHook as LTMArgumentsHook,
+    LTMInjectionHook as LTMInjectionHook,
+    LTMMCPClient as LTMMCPClient,
+    LTMSavingConsolidator as LTMSavingConsolidator,
+    build_ltm_hooks as build_ltm_hooks,
+    install_ltm_saving as install_ltm_saving,
 )

--- a/src/nanobot_runtime/clients/desktop_mate_rest.py
+++ b/src/nanobot_runtime/clients/desktop_mate_rest.py
@@ -11,6 +11,7 @@ Auth model is intentionally simpler than nanobot's TTL-bound token pool:
 we reuse the static ``?token=`` used for the WebSocket handshake.
 Rotating tokens can layer on later without changing the REST shape.
 """
+
 import email.utils
 import http
 import json
@@ -122,7 +123,9 @@ def _token_valid(token_cfg: str, request: WsRequest) -> bool:
     return supplied is not None and supplied == expected
 
 
-def handle_sessions_list(token: str, session_manager: Any, request: WsRequest) -> Response:
+def handle_sessions_list(
+    token: str, session_manager: Any, request: WsRequest
+) -> Response:
     if not _token_valid(token, request):
         return http_error(401, "Unauthorized")
     if session_manager is None:

--- a/src/nanobot_runtime/clients/irodori.py
+++ b/src/nanobot_runtime/clients/irodori.py
@@ -56,7 +56,9 @@ class IrodoriClient:
 
     # ── TTSSynthesizer Protocol ───────────────────────────────────────
 
-    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
+    async def synthesize(
+        self, text: str, *, reference_id: str | None = None
+    ) -> str | None:
         tts_text = text.strip() if text else ""
         if not tts_text:
             return None
@@ -132,10 +134,9 @@ class IrodoriClient:
                     response = await client.post(url, data=data)
                 response.raise_for_status()
                 return bytes(response.content)
-        except httpx.HTTPStatusError as exc:
-            logger.error(
-                "IrodoriClient HTTP error {} from {}",
-                exc.response.status_code,
+        except httpx.HTTPStatusError:
+            logger.exception(
+                "IrodoriClient HTTP error from {}",
                 url,
             )
             return None

--- a/src/nanobot_runtime/clients/ltm.py
+++ b/src/nanobot_runtime/clients/ltm.py
@@ -3,6 +3,7 @@
 Matches the Protocol expected by LTMInjectionHook (and future LTM hooks),
 so production code uses the real ltm-mcp server while tests inject fakes.
 """
+
 from typing import Any
 
 from fastmcp import Client

--- a/src/nanobot_runtime/config/desktop_mate.py
+++ b/src/nanobot_runtime/config/desktop_mate.py
@@ -1,4 +1,5 @@
 """Config model and helpers for DesktopMateChannel."""
+
 from typing import Any
 
 from loguru import logger
@@ -14,10 +15,16 @@ class DesktopMateConfig(BaseModel):
     """
 
     enabled: bool = Field(default=True, description="Whether the channel is active.")
-    host: str = Field(default="127.0.0.1", description="Bind address for the WebSocket server.")
-    port: int = Field(default=8765, description="TCP port the WebSocket server listens on.")
+    host: str = Field(
+        default="127.0.0.1", description="Bind address for the WebSocket server."
+    )
+    port: int = Field(
+        default=8765, description="TCP port the WebSocket server listens on."
+    )
     path: str = Field(default="/ws", description="URL path for the WebSocket endpoint.")
-    token: str = Field(default="", description="Static bearer token; empty means no auth required.")
+    token: str = Field(
+        default="", description="Static bearer token; empty means no auth required."
+    )
     allow_from: list[str] = Field(
         default_factory=lambda: ["*"],
         description="Allowlist of client_id values; '*' accepts any client.",

--- a/src/nanobot_runtime/config/idle.py
+++ b/src/nanobot_runtime/config/idle.py
@@ -1,4 +1,5 @@
 """Configuration models for the idle-watcher system job."""
+
 from typing import Awaitable, Callable
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -23,7 +24,9 @@ class QuietHours(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     start: str = Field(description="HH:MM quiet-hours start in config timezone.")
-    end: str = Field(description="HH:MM quiet-hours end. If start > end, window spans midnight.")
+    end: str = Field(
+        description="HH:MM quiet-hours end. If start > end, window spans midnight."
+    )
 
 
 class IdleConfig(BaseModel):
@@ -31,10 +34,18 @@ class IdleConfig(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    enabled: bool = Field(default=True, description="Enable or disable the idle watcher entirely.")
-    idle_timeout_s: int = Field(default=300, description="Seconds of silence before a nudge is sent.")
-    cooldown_s: int = Field(default=900, description="Minimum seconds between nudges for the same session.")
-    scan_interval_s: int = Field(default=30, description="How often the watcher scans sessions (seconds).")
+    enabled: bool = Field(
+        default=True, description="Enable or disable the idle watcher entirely."
+    )
+    idle_timeout_s: int = Field(
+        default=300, description="Seconds of silence before a nudge is sent."
+    )
+    cooldown_s: int = Field(
+        default=900, description="Minimum seconds between nudges for the same session."
+    )
+    scan_interval_s: int = Field(
+        default=30, description="How often the watcher scans sessions (seconds)."
+    )
     startup_grace_s: int = Field(
         default=120,
         ge=0,
@@ -42,10 +53,19 @@ class IdleConfig(BaseModel):
         "Prevents the reboot-storm where dormant sessions trigger bulk nudges before "
         "the in-memory cooldown table has been populated.",
     )
-    quiet_hours: "QuietHours | None" = Field(default=None, description="Time window during which nudges are suppressed.")
-    timezone: str = Field(default="UTC", description="IANA timezone name for quiet-hours evaluation.")
-    channels: tuple[str, ...] = Field(default=("desktop_mate",), description="Channel names that receive idle nudges.")
-    idle_prompt: str = Field(default=_DEFAULT_IDLE_PROMPT, description="Prompt template; {minutes} is substituted.")
+    quiet_hours: "QuietHours | None" = Field(
+        default=None, description="Time window during which nudges are suppressed."
+    )
+    timezone: str = Field(
+        default="UTC", description="IANA timezone name for quiet-hours evaluation."
+    )
+    channels: tuple[str, ...] = Field(
+        default=("desktop_mate",), description="Channel names that receive idle nudges."
+    )
+    idle_prompt: str = Field(
+        default=_DEFAULT_IDLE_PROMPT,
+        description="Prompt template; {minutes} is substituted.",
+    )
     context_providers: tuple[Callable[[], Awaitable[str]], ...] = Field(
         default_factory=tuple,
         description="Reserved for Phase 5.5 context injection.",

--- a/src/nanobot_runtime/core/__init__.py
+++ b/src/nanobot_runtime/core/__init__.py
@@ -1,3 +1,7 @@
 """Core infrastructure: logging, error classification."""
-from nanobot_runtime.core.error_classifier import ErrorClassifier, ErrorSeverity
-from nanobot_runtime.core.logger import setup_logging
+
+from nanobot_runtime.core.error_classifier import (
+    ErrorClassifier as ErrorClassifier,
+    ErrorSeverity as ErrorSeverity,
+)
+from nanobot_runtime.core.logger import setup_logging as setup_logging

--- a/src/nanobot_runtime/gateway.py
+++ b/src/nanobot_runtime/gateway.py
@@ -15,6 +15,7 @@ spawn to ``run``, we guarantee both a live loop and a fully-wired agent.
 
 Pinned to nanobot 0.1.5.x — version drift fails loud at startup.
 """
+
 import asyncio
 import inspect
 import os
@@ -167,7 +168,13 @@ def run(
     resolved_config = config_path or os.getenv("NANOBOT_CONFIG", "./nanobot.json")
     resolved_workspace = workspace or os.getenv("NANOBOT_WORKSPACE", ".")
     app(
-        args=["gateway", "--config", resolved_config, "--workspace", resolved_workspace],
+        args=[
+            "gateway",
+            "--config",
+            resolved_config,
+            "--workspace",
+            resolved_workspace,
+        ],
         prog_name="nanobot",
         standalone_mode=False,
     )

--- a/src/nanobot_runtime/launcher.py
+++ b/src/nanobot_runtime/launcher.py
@@ -12,6 +12,7 @@ Default paths resolve against the workspace working directory (cwd), not
 against this file's location, so the launcher stays portable when
 installed as a console script in a workspace ``.venv``.
 """
+
 import os
 
 from nanobot.agent.hook import AgentHook

--- a/src/nanobot_runtime/models/desktop_mate.py
+++ b/src/nanobot_runtime/models/desktop_mate.py
@@ -24,6 +24,7 @@ channel layer so every failure mode surfaces to the client as an
 particular must not fail at the Pydantic boundary, because a schema
 ValidationError would be silently dropped by the inbound loop).
 """
+
 from typing import Annotated, Any, Literal, Union
 
 from pydantic import (

--- a/src/nanobot_runtime/services/channels/__init__.py
+++ b/src/nanobot_runtime/services/channels/__init__.py
@@ -1,5 +1,6 @@
 """DesktopMate channel — DMP-compatible WebSocket server + TTSSink."""
+
 from nanobot_runtime.services.channels.desktop_mate import (
-    DesktopMateChannel,
-    DesktopMateConfig,
+    DesktopMateChannel as DesktopMateChannel,
+    DesktopMateConfig as DesktopMateConfig,
 )

--- a/src/nanobot_runtime/services/channels/desktop_mate.py
+++ b/src/nanobot_runtime/services/channels/desktop_mate.py
@@ -9,6 +9,7 @@ via the TTS Barrier) still have a chat_id to route to.
 
 Auth: single static token against ``?token=`` in the WS URL.
 """
+
 import asyncio
 import re
 import time
@@ -25,7 +26,10 @@ from nanobot.bus.queue import MessageBus
 from nanobot.channels.base import BaseChannel
 
 from nanobot_runtime.config.desktop_mate import DesktopMateConfig, _coerce_config
-from nanobot_runtime.services.channels.desktop_mate_image import _MAX_IMAGE_BYTES, _decode_images
+from nanobot_runtime.services.channels.desktop_mate_image import (
+    _MAX_IMAGE_BYTES,
+    _decode_images,
+)
 from nanobot_runtime.models.desktop_mate import (
     DeltaFrame,
     ImageRejectReason,
@@ -33,8 +37,13 @@ from nanobot_runtime.models.desktop_mate import (
     StreamEndFrame,
     StreamStartFrame,
 )
-from nanobot_runtime.clients.desktop_mate_rest import dispatch_http, parse_request_path, query_first
-from nanobot_runtime.services.channels.desktop_mate_server import _DesktopMateServerMixin
+from nanobot_runtime.clients.desktop_mate_rest import (
+    dispatch_http,
+    query_first,
+)
+from nanobot_runtime.services.channels.desktop_mate_server import (
+    _DesktopMateServerMixin,
+)
 from nanobot_runtime.services.channels.desktop_mate_tts import _DesktopMateTTSMixin
 from nanobot_runtime.services.hooks.tts import TTSChunk, TTSSink
 from nanobot_runtime.services.tts.emotion_mapper import EmotionMapper
@@ -95,12 +104,15 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         if emotion_emojis is not None:
             self._emotion_emojis: frozenset[str] = frozenset(emotion_emojis)
         elif coerced.emotion_map_path:
-            self._emotion_emojis = EmotionMapper.from_yaml(coerced.emotion_map_path).known_emojis
+            self._emotion_emojis = EmotionMapper.from_yaml(
+                coerced.emotion_map_path
+            ).known_emojis
         else:
             self._emotion_emojis = frozenset()
         self._emotion_strip_re: re.Pattern[str] | None = (
             re.compile("|".join(re.escape(e) for e in self._emotion_emojis))
-            if self._emotion_emojis else None
+            if self._emotion_emojis
+            else None
         )
         self._chat_conn: dict[str, Any] = {}
         self._streams: dict[str, tuple[str, bool]] = {}
@@ -149,6 +161,7 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         if self._media_dir is not None:
             return self._media_dir
         from nanobot.config.paths import get_media_dir
+
         self._media_dir = get_media_dir("desktop_mate")
         return self._media_dir
 
@@ -172,7 +185,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         try:
             await connection.send(raw)
         except Exception:
-            logger.opt(exception=True).warning("desktop_mate: send failed, dropping connection")
+            logger.opt(exception=True).warning(
+                "desktop_mate: send failed, dropping connection"
+            )
             self._detach_connection(connection)
 
     async def _send_ready(self, connection: Any, *, client_id: str) -> str:
@@ -180,7 +195,11 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         connection_id = str(uuid.uuid4())
         await self._send_frame(
             connection,
-            ReadyFrame(connection_id=connection_id, client_id=client_id, server_time=time.time()),
+            ReadyFrame(
+                connection_id=connection_id,
+                client_id=client_id,
+                server_time=time.time(),
+            ),
         )
         return connection_id
 
@@ -200,7 +219,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
             if stream_id:
                 self._streams[stream_id] = (msg.chat_id, bool(proactive_flag))
                 self._current_stream_id = stream_id
-            await self._send_frame(conn, StreamStartFrame(chat_id=msg.chat_id, proactive=proactive_flag))
+            await self._send_frame(
+                conn, StreamStartFrame(chat_id=msg.chat_id, proactive=proactive_flag)
+            )
             return
 
         # Nanobot calls send() once per agent iteration, not just at the
@@ -221,7 +242,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
                     "desktop_mate: send() with neither _stream_end nor tool "
                     "metadata (chat_id={}, content_len={}) — possible nanobot "
                     "shape change; FE may hang. meta_keys={}",
-                    msg.chat_id, len(msg.content or ""), list(meta.keys()),
+                    msg.chat_id,
+                    len(msg.content or ""),
+                    list(meta.keys()),
                 )
             return
 
@@ -231,7 +254,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         # or the connection drops.
         await self._send_frame(
             conn,
-            StreamEndFrame(chat_id=msg.chat_id, content=msg.content, proactive=proactive_flag),
+            StreamEndFrame(
+                chat_id=msg.chat_id, content=msg.content, proactive=proactive_flag
+            ),
         )
 
     async def send_delta(
@@ -242,7 +267,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
     ) -> None:
         conn = self._chat_conn.get(chat_id)
         if conn is None:
-            logger.warning("desktop_mate: send_delta: no connection for chat_id={}", chat_id)
+            logger.warning(
+                "desktop_mate: send_delta: no connection for chat_id={}", chat_id
+            )
             return
 
         meta = metadata or {}
@@ -276,12 +303,16 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
         if bool(stream_id) and stream_id not in self._streams:
             self._streams[stream_id] = (chat_id, bool(proactive_flag))
             self._current_stream_id = stream_id
-            await self._send_frame(conn, StreamStartFrame(chat_id=chat_id, proactive=proactive_flag))
+            await self._send_frame(
+                conn, StreamStartFrame(chat_id=chat_id, proactive=proactive_flag)
+            )
 
         if meta.get("_stream_end"):
             await self._send_frame(
                 conn,
-                StreamEndFrame(chat_id=chat_id, content=delta, proactive=proactive_flag),
+                StreamEndFrame(
+                    chat_id=chat_id, content=delta, proactive=proactive_flag
+                ),
             )
             return
 
@@ -298,7 +329,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
     # ── REST Surface ──────────────────────────────────────────────────────
 
     async def _dispatch_http(self, connection: Any, request: WsRequest) -> Any:
-        return dispatch_http(self.config.token, self._session_manager, self.config.path, request)
+        return dispatch_http(
+            self.config.token, self._session_manager, self.config.path, request
+        )
 
     # ── Auth / Handshake ──────────────────────────────────────────────────
 
@@ -314,7 +347,9 @@ class DesktopMateChannel(_DesktopMateTTSMixin, _DesktopMateServerMixin, BaseChan
             try:
                 await connection.close(code=4003, reason="invalid token")
             except Exception:
-                logger.opt(exception=True).warning("desktop_mate: close after bad token raised")
+                logger.opt(exception=True).warning(
+                    "desktop_mate: close after bad token raised"
+                )
             return False
         return True
 
@@ -375,7 +410,7 @@ class LazyChannelTTSSink(TTSSink):
             # time. Warn once per process so a "TTS missing on first message
             # after restart" doesn't look identical to a config bug.
             if not self._race_tolerance_warned:
-                logger.warning(
+                logger.opt(exception=True).warning(
                     "LazyChannelTTSSink.is_enabled: DesktopMateChannel not "
                     "registered yet (session_key={}); allowing dispatch on "
                     "the assumption it will register before delivery.",
@@ -389,7 +424,7 @@ class LazyChannelTTSSink(TTSSink):
             channel = get_desktop_mate_channel()
         except RuntimeError:
             if not self._dropped_chunk_warned:
-                logger.warning(
+                logger.opt(exception=True).warning(
                     "LazyChannelTTSSink.send_tts_chunk: dropping TTSChunk "
                     "seq={} — DesktopMateChannel still not registered.",
                     chunk.sequence,

--- a/src/nanobot_runtime/services/channels/desktop_mate_image.py
+++ b/src/nanobot_runtime/services/channels/desktop_mate_image.py
@@ -4,10 +4,10 @@ Validates count, MIME type, size, and base64 integrity; persists decoded
 images to the media directory. Every failure surfaces to the caller as an
 ``ImageRejectReason`` token so the FE can handle it without parsing prose.
 """
+
 import binascii
 import re
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 
@@ -23,12 +23,14 @@ from nanobot_runtime.models.desktop_mate import (
 _MAX_IMAGE_BYTES = 10 * 1024 * 1024
 
 # SVG is excluded to avoid embedded-script XSS surface.
-_IMAGE_MIME_ALLOWED: frozenset[str] = frozenset({
-    "image/png",
-    "image/jpeg",
-    "image/webp",
-    "image/gif",
-})
+_IMAGE_MIME_ALLOWED: frozenset[str] = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "image/gif",
+    }
+)
 
 _DATA_URL_MIME_RE = re.compile(r"^data:([^;]+);base64,", re.DOTALL)
 
@@ -61,7 +63,9 @@ def _decode_images(
     if len(images) > _MAX_IMAGES_PER_MESSAGE:
         logger.warning(
             "desktop_mate: rejecting images from {}: count={} exceeds cap={}",
-            sender_id, len(images), _MAX_IMAGES_PER_MESSAGE,
+            sender_id,
+            len(images),
+            _MAX_IMAGES_PER_MESSAGE,
         )
         return [], "too_many"
 
@@ -76,13 +80,18 @@ def _decode_images(
         level = "error" if reason == "io_error" else "warning"
         getattr(logger, level)(
             "desktop_mate: rejecting image from {}: reason={} mime={} size_hint={}",
-            sender_id, reason, mime, size_hint,
+            sender_id,
+            reason,
+            mime,
+            size_hint,
         )
         for p in saved_paths:
             try:
                 Path(p).unlink(missing_ok=True)
-            except OSError as exc:
-                logger.warning("desktop_mate: failed to unlink partial media {}: {}", p, exc)
+            except OSError:
+                logger.opt(exception=True).warning(
+                    "desktop_mate: failed to unlink partial media {}", p
+                )
         return [], reason
 
     for entry in images:
@@ -98,7 +107,9 @@ def _decode_images(
         except FileSizeExceeded:
             return _abort("too_large", mime=mime, size_hint=len(entry))
         except (binascii.Error, ValueError):
-            logger.opt(exception=True).warning("desktop_mate: decode failed (caller-fixable)")
+            logger.opt(exception=True).warning(
+                "desktop_mate: decode failed (caller-fixable)"
+            )
             return _abort("malformed", mime=mime, size_hint=len(entry))
         except OSError:
             logger.opt(exception=True).error("desktop_mate: image persist failed")

--- a/src/nanobot_runtime/services/channels/desktop_mate_server.py
+++ b/src/nanobot_runtime/services/channels/desktop_mate_server.py
@@ -8,6 +8,7 @@ State from ``DesktopMateChannel.__init__``: ``config``, ``_stop_event``,
 ``_send_ready``, ``_decode_inbound_images``, ``_attach``, ``_send_frame``,
 ``_detach_connection``, ``_handle_message``, and ``is_allowed``.
 """
+
 import asyncio
 import uuid
 from pathlib import Path
@@ -43,15 +44,17 @@ class _DesktopMateServerMixin:
                 try:
                     raw = raw.decode("utf-8")
                 except UnicodeDecodeError:
-                    logger.warning("desktop_mate: non-utf8 binary frame, ignored")
+                    logger.opt(exception=True).warning(
+                        "desktop_mate: non-utf8 binary frame, ignored"
+                    )
                     continue
 
             try:
                 envelope = parse_inbound(raw)
-            except (ValidationError, ValueError) as e:
-                logger.warning(
-                    "desktop_mate: bad inbound frame, ignored: {} ({!r})",
-                    e, raw[:100],
+            except (ValidationError, ValueError):
+                logger.opt(exception=True).warning(
+                    "desktop_mate: bad inbound frame, ignored ({!r})",
+                    raw[:100],
                 )
                 continue
 
@@ -68,7 +71,8 @@ class _DesktopMateServerMixin:
                 chat_id = envelope.chat_id
 
             media_paths, reject_reason = self._decode_inbound_images(  # type: ignore[attr-defined]
-                envelope.images, sender_id=sender_id,
+                envelope.images,
+                sender_id=sender_id,
             )
             if reject_reason is not None:
                 # new_chat rejections have no chat_id yet; FE correlates via reference_id.
@@ -106,10 +110,10 @@ class _DesktopMateServerMixin:
                 for p in media_paths:
                     try:
                         Path(p).unlink(missing_ok=True)
-                    except OSError as unlink_exc:
-                        logger.warning(
-                            "desktop_mate: leaked media {} (unlink after failure): {}",
-                            p, unlink_exc,
+                    except OSError:
+                        logger.opt(exception=True).warning(
+                            "desktop_mate: leaked media {} (unlink after failure)",
+                            p,
                         )
 
     # ── Server Lifecycle ──────────────────────────────────────────────────
@@ -137,7 +141,9 @@ class _DesktopMateServerMixin:
                 try:
                     await connection.close(code=4003, reason="forbidden")
                 except Exception:
-                    logger.opt(exception=True).warning("desktop_mate: close(4003/forbidden) raised")
+                    logger.opt(exception=True).warning(
+                        "desktop_mate: close(4003/forbidden) raised"
+                    )
                 return
 
             self._apply_connection_tts_override(connection, query)  # type: ignore[attr-defined]
@@ -156,7 +162,9 @@ class _DesktopMateServerMixin:
         config = self.config  # type: ignore[attr-defined]
         logger.info(
             "desktop_mate: listening on ws://{}:{}{}",
-            config.host, config.port, config.path,
+            config.host,
+            config.port,
+            config.path,
         )
 
         async def runner() -> None:
@@ -192,10 +200,14 @@ class _DesktopMateServerMixin:
             try:
                 await asyncio.wait_for(server_task, timeout=2.0)
             except asyncio.TimeoutError:
-                logger.warning("desktop_mate: server task did not stop within 2s, cancelling")
+                logger.opt(exception=True).warning(
+                    "desktop_mate: server task did not stop within 2s, cancelling"
+                )
                 server_task.cancel()
             except Exception:
-                logger.opt(exception=True).warning("desktop_mate: server task ended with error during stop")
+                logger.opt(exception=True).warning(
+                    "desktop_mate: server task ended with error during stop"
+                )
             self._server_task = None  # type: ignore[attr-defined]
         self._chat_conn.clear()  # type: ignore[attr-defined]
         self._streams.clear()  # type: ignore[attr-defined]

--- a/src/nanobot_runtime/services/channels/desktop_mate_tts.py
+++ b/src/nanobot_runtime/services/channels/desktop_mate_tts.py
@@ -7,6 +7,7 @@ Methods access state initialised in DesktopMateChannel.__init__:
 ``_tts_enabled_per_chat``, ``_tts_enabled_per_conn``, ``_current_stream_id``,
 ``_streams``, ``_chat_conn``, ``_emotion_strip_re``, and ``_send_frame``.
 """
+
 from typing import Any
 
 from loguru import logger

--- a/src/nanobot_runtime/services/hooks/__init__.py
+++ b/src/nanobot_runtime/services/hooks/__init__.py
@@ -1,13 +1,16 @@
 """AgentLoop hooks + a factory that wires a standard LTM hook set."""
+
 from nanobot.agent.hook import AgentHook
 
-from nanobot_runtime.services.hooks.ltm.args import LTMArgumentsHook
-from nanobot_runtime.clients.ltm import LTMMCPClient
+from nanobot_runtime.services.hooks.ltm.args import LTMArgumentsHook as LTMArgumentsHook
+from nanobot_runtime.clients.ltm import LTMMCPClient as LTMMCPClient
 from nanobot_runtime.services.hooks.ltm.consolidator import (
-    LTMSavingConsolidator,
-    install_ltm_saving,
+    LTMSavingConsolidator as LTMSavingConsolidator,
+    install_ltm_saving as install_ltm_saving,
 )
-from nanobot_runtime.services.hooks.ltm.injection import LTMInjectionHook
+from nanobot_runtime.services.hooks.ltm.injection import (
+    LTMInjectionHook as LTMInjectionHook,
+)
 
 
 def build_ltm_hooks(
@@ -36,5 +39,3 @@ def build_ltm_hooks(
         ),
         LTMArgumentsHook(user_id=user_id, agent_id=agent_id),
     ]
-
-

--- a/src/nanobot_runtime/services/hooks/ltm/args.py
+++ b/src/nanobot_runtime/services/hooks/ltm/args.py
@@ -6,6 +6,7 @@ place of `user_id`, causing empty search results). This hook rewrites
 those two arguments just before tool dispatch, after the model has
 already decided which tool to call.
 """
+
 from nanobot.agent.hook import AgentHook, AgentHookContext
 
 _LTM_TOOL_PREFIX = "mcp_ltm_"

--- a/src/nanobot_runtime/services/hooks/ltm/consolidator.py
+++ b/src/nanobot_runtime/services/hooks/ltm/consolidator.py
@@ -17,6 +17,7 @@ loop.consolidator in place. This matters because:
 Both paths therefore route through the LTM-saving wrapper without needing
 to reconstruct the inner Consolidator or re-wire AutoCompact.
 """
+
 import asyncio
 from typing import Any, Protocol
 
@@ -65,9 +66,7 @@ class LTMSavingConsolidator:
             await self._push_to_ltm(messages, summary)
         return summary
 
-    async def _push_to_ltm(
-        self, messages: list[dict[str, Any]], summary: str
-    ) -> None:
+    async def _push_to_ltm(self, messages: list[dict[str, Any]], summary: str) -> None:
         tasks = [self._safe_add(f"[conversation summary] {summary}")]
         for msg in messages:
             if msg.get("role") != "user":
@@ -76,7 +75,13 @@ class LTMSavingConsolidator:
             if not content or not isinstance(content, str):
                 continue
             tasks.append(self._safe_add(content))
-        await asyncio.gather(*tasks, return_exceptions=True)
+        aws = [asyncio.ensure_future(t) for t in tasks]
+        done, _ = await asyncio.wait(aws)
+        for fut in done:
+            if fut.exception() is not None:
+                logger.opt(exception=fut.exception()).warning(
+                    "LTM _push_to_ltm: unexpected exception from _safe_add"
+                )
 
     async def _safe_add(self, content: str) -> None:
         try:
@@ -86,9 +91,7 @@ class LTMSavingConsolidator:
                 agent_id=self._agent_id,
             )
         except Exception:
-            logger.exception(
-                "LTM add_memory failed (content[:60]={!r})", content[:60]
-            )
+            logger.exception("LTM add_memory failed (content[:60]={!r})", content[:60])
 
 
 def install_ltm_saving(

--- a/src/nanobot_runtime/services/hooks/ltm/injection.py
+++ b/src/nanobot_runtime/services/hooks/ltm/injection.py
@@ -4,6 +4,7 @@ Fires on `before_iteration` at the start of each user turn (iteration==0),
 searches mem0 with the latest user utterance, and appends a summary block to
 the first system message so the LLM can ground the reply in persisted facts.
 """
+
 from typing import Any, Protocol
 
 from loguru import logger
@@ -92,7 +93,9 @@ class LTMInjectionHook(AgentHook):
 
         block = _format_memories(results)
         _append_to_system_message(context.messages, block)
-        logger.info("LTM injection: {} memories for user={}", len(results), self._user_id)
+        logger.info(
+            "LTM injection: {} memories for user={}", len(results), self._user_id
+        )
 
 
 def _already_injected(messages: list[dict[str, Any]]) -> bool:

--- a/src/nanobot_runtime/services/hooks/tts/__init__.py
+++ b/src/nanobot_runtime/services/hooks/tts/__init__.py
@@ -1,0 +1,24 @@
+"""TTS hook package — re-exports for backward-compatible import paths."""
+
+from nanobot_runtime.services.hooks.tts.abc import TTSSink
+from nanobot_runtime.services.hooks.tts.hook import TTSHook, _FALLBACK_SESSION_KEY
+from nanobot_runtime.services.hooks.tts.models import TTSChunk
+from nanobot_runtime.services.hooks.tts.protocols import (
+    EmotionMapper,
+    ReferenceIdResolver,
+    SentenceChunker,
+    TextPreprocessor,
+    TTSSynthesizer,
+)
+
+__all__ = [
+    "TTSChunk",
+    "TTSSink",
+    "TTSHook",
+    "_FALLBACK_SESSION_KEY",
+    "SentenceChunker",
+    "TextPreprocessor",
+    "EmotionMapper",
+    "TTSSynthesizer",
+    "ReferenceIdResolver",
+]

--- a/src/nanobot_runtime/services/hooks/tts/abc.py
+++ b/src/nanobot_runtime/services/hooks/tts/abc.py
@@ -1,0 +1,33 @@
+"""TTSSink — abstract base class for downstream TTS chunk consumers."""
+
+from abc import ABC, abstractmethod
+
+from nanobot_runtime.services.hooks.tts.models import TTSChunk
+
+
+class TTSSink(ABC):
+    """Contract for downstream consumers of synthesized TTS chunks.
+
+    Promoted from a `Protocol` with an optional `is_enabled` to an ABC so
+    every sink — production (`LazyChannelTTSSink`), regression harness
+    (`DirectSink`), and test fakes — implements the same contract. The
+    hook can then call `self._sink.is_enabled(session_key)` directly,
+    with no `getattr` introspection and no implicit "always enabled"
+    fallback. A sink that forgets either method fails at construction
+    time with a clear `TypeError`, not at the dispatch hot path with an
+    `AttributeError`.
+    """
+
+    @abstractmethod
+    async def send_tts_chunk(self, chunk: TTSChunk) -> None: ...
+
+    @abstractmethod
+    def is_enabled(self, session_key: str | None) -> bool:
+        """Return True iff this sink is willing to deliver audio for the
+        given session. The hook calls this once at dispatch time and once
+        again inside the synth task (second-chance check), both with the
+        same ``state.session_key``. Sinks that don't care about the
+        channel implement this trivially (return True or check internal
+        state). ``session_key`` is required positionally — there is no
+        default; pass ``None`` explicitly when no key is available.
+        """

--- a/src/nanobot_runtime/services/hooks/tts/hook.py
+++ b/src/nanobot_runtime/services/hooks/tts/hook.py
@@ -31,96 +31,28 @@ consume a sequence number. When ``session_key`` is ``None``
 (caller didn't supply one — stale nanobot, or a test) the hook falls back
 to a shared ``_default`` state bucket and emits a warning once.
 """
+
 import asyncio
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable, Protocol
+from typing import Callable
 
 from loguru import logger
 from nanobot.agent.hook import AgentHook, AgentHookContext
-from pydantic import BaseModel, ConfigDict, Field
+
+from nanobot_runtime.services.hooks.tts.abc import TTSSink
+from nanobot_runtime.services.hooks.tts.models import TTSChunk
+from nanobot_runtime.services.hooks.tts.protocols import (
+    EmotionMapper,
+    ReferenceIdResolver,
+    SentenceChunker,
+    TextPreprocessor,
+    TTSSynthesizer,
+)
+
+_FALLBACK_SESSION_KEY = "__tts_hook_default__"
 
 
-# ── Data shape emitted to the sink (matches DMP's tts_chunk frame payload)
-
-
-class TTSChunk(BaseModel):
-    """Data emitted to the TTS sink per completed sentence."""
-
-    model_config = ConfigDict(frozen=True)
-
-    sequence: int = Field(description="Zero-based index of this chunk within the current stream.")
-    text: str = Field(description="Cleaned sentence text sent to the TTS engine.")
-    audio_base64: str | None = Field(description="Base64-encoded WAV audio, or None on failure.")
-    emotion: str | None = Field(description="Detected emotion emoji/tag, or None.")
-    keyframes: list[dict[str, Any]] = Field(
-        default_factory=list, description="Animation keyframe dicts for the emotion."
-    )
-
-
-# ── Injected dependencies (Protocols) ────────────────────────────────────
-
-
-class SentenceChunker(Protocol):
-    def feed(self, delta: str) -> list[str]: ...
-    def flush(self) -> str | None: ...
-
-
-class TextPreprocessor(Protocol):
-    def process(self, sentence: str) -> tuple[str, str | None]:
-        """Return (clean_text_for_display, emotion_tag_or_None)."""
-
-
-class EmotionMapper(Protocol):
-    def map(self, emotion: str | None) -> list[dict[str, Any]]: ...
-
-
-class TTSSynthesizer(Protocol):
-    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
-        """Return base64-encoded audio (wav) or None on failure.
-
-        ``reference_id`` is an optional per-call voice override. ``None``
-        means "use the synthesizer's default"; an empty string forces no
-        reference even when the synthesizer has a baked-in default.
-        """
-
-
-# Resolves a session_key (``"desktop_mate:<chat_id>"``-style) to the voice
-# to use for that session, or ``None`` to fall back to the synthesizer's
-# default. The hook calls this *once per sentence dispatch*, so the resolver
-# may consult mutable channel state without stale-cache concerns.
-ReferenceIdResolver = Callable[[str | None], str | None]
-
-
-class TTSSink(ABC):
-    """Contract for downstream consumers of synthesized TTS chunks.
-
-    Promoted from a `Protocol` with an optional `is_enabled` to an ABC so
-    every sink — production (`LazyChannelTTSSink`), regression harness
-    (`DirectSink`), and test fakes — implements the same contract. The
-    hook can then call `self._sink.is_enabled(session_key)` directly,
-    with no `getattr` introspection and no implicit "always enabled"
-    fallback. A sink that forgets either method fails at construction
-    time with a clear `TypeError`, not at the dispatch hot path with an
-    `AttributeError`.
-    """
-
-    @abstractmethod
-    async def send_tts_chunk(self, chunk: TTSChunk) -> None: ...
-
-    @abstractmethod
-    def is_enabled(self, session_key: str | None) -> bool:
-        """Return True iff this sink is willing to deliver audio for the
-        given session. The hook calls this once at dispatch time and once
-        again inside the synth task (second-chance check), both with the
-        same ``state.session_key``. Sinks that don't care about the
-        channel implement this trivially (return True or check internal
-        state). ``session_key`` is required positionally — there is no
-        default; pass ``None`` explicitly when no key is available.
-        """
-
-
-# ── Per-session state ─────────────────────────────────────────────────────
+# ── Per-session state ─────────────────────────────────────────────────────────
 
 
 @dataclass(slots=True)
@@ -133,13 +65,25 @@ class _SessionState:
     session_key: str | None = None
 
 
-_FALLBACK_SESSION_KEY = "__tts_hook_default__"
-
-
-# ── Hook ─────────────────────────────────────────────────────────────────
+# ── Hook ──────────────────────────────────────────────────────────────────────
 
 
 class TTSHook(AgentHook):
+    """nanobot AgentHook that drives the TTS synthesis pipeline.
+
+    Args:
+        chunker_factory: Zero-argument callable returning a fresh SentenceChunker
+            per session.
+        preprocessor: Cleans sentence text and extracts emotion tags.
+        emotion_mapper: Maps emotion tags to animation keyframe dicts.
+        synthesizer: Async TTS backend; returns base64 WAV or None on failure.
+        sink: Downstream consumer of completed TTSChunks.
+        barrier_timeout_seconds: How long on_stream_end waits for in-flight
+            synthesis tasks before cancelling them.
+        reference_id_resolver: Optional per-session voice resolver. Called once
+            per sentence dispatch; ``None`` falls back to synthesizer default.
+    """
+
     def __init__(
         self,
         *,
@@ -172,9 +116,7 @@ class TTSHook(AgentHook):
         for sentence in state.chunker.feed(delta):
             self._dispatch_sentence(state, sentence)
 
-    async def on_stream_end(
-        self, context: AgentHookContext, *, resuming: bool
-    ) -> None:
+    async def on_stream_end(self, context: AgentHookContext, *, resuming: bool) -> None:
         # Mid-turn break (tool call imminent) — do not flush. Partial buffer
         # must carry across the tool loop so a single logical response does
         # not get split into separate TTS groups.
@@ -194,28 +136,26 @@ class TTSHook(AgentHook):
         # TTS Barrier: block until every pending synth task settles, so the
         # caller (channel) can emit stream_end immediately after this returns.
         if state.pending:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*state.pending, return_exceptions=True),
-                    timeout=self._barrier_timeout,
-                )
-            except TimeoutError:
+            done, pending_set = await asyncio.wait(
+                state.pending,
+                timeout=self._barrier_timeout,
+            )
+            if pending_set:
                 logger.warning(
                     "TTS Barrier timeout ({}s) — {} tasks still pending; "
                     "cancelling. (session={})",
                     self._barrier_timeout,
-                    sum(1 for t in state.pending if not t.done()),
+                    len(pending_set),
                     key,
                 )
-                for t in state.pending:
-                    if not t.done():
-                        t.cancel()
+                for t in pending_set:
+                    t.cancel()
 
         # Turn fully wrapped — drop the per-session bucket so the next turn
         # for the same session starts clean (sequence back to 0, fresh chunker).
         self._states.pop(key, None)
 
-    # ── Internals ─────────────────────────────────────────────────────
+    # ── Internals ─────────────────────────────────────────────────────────────
 
     def _session_key(self, context: AgentHookContext) -> str:
         key = getattr(context, "session_key", None)
@@ -246,7 +186,9 @@ class TTSHook(AgentHook):
         except Exception:
             # Resolver failure must not block synthesis — fall back to the
             # synthesizer's constructor default.
-            logger.exception("TTSHook reference_id resolver raised (session={})", session_key)
+            logger.exception(
+                "TTSHook reference_id resolver raised (session={})", session_key
+            )
             return None
 
     def _dispatch_sentence(self, state: _SessionState, sentence: str) -> None:
@@ -288,7 +230,9 @@ class TTSHook(AgentHook):
         if not self._sink.is_enabled(session_key):
             return
         try:
-            audio_b64 = await self._synthesizer.synthesize(text, reference_id=reference_id)
+            audio_b64 = await self._synthesizer.synthesize(
+                text, reference_id=reference_id
+            )
         except Exception:
             logger.exception("TTS synth failed (seq={})", sequence)
             audio_b64 = None

--- a/src/nanobot_runtime/services/hooks/tts/models.py
+++ b/src/nanobot_runtime/services/hooks/tts/models.py
@@ -1,0 +1,23 @@
+"""TTSChunk — data shape emitted to the TTS sink per completed sentence."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TTSChunk(BaseModel):
+    """Data emitted to the TTS sink per completed sentence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    sequence: int = Field(
+        description="Zero-based index of this chunk within the current stream."
+    )
+    text: str = Field(description="Cleaned sentence text sent to the TTS engine.")
+    audio_base64: str | None = Field(
+        description="Base64-encoded WAV audio, or None on failure."
+    )
+    emotion: str | None = Field(description="Detected emotion emoji/tag, or None.")
+    keyframes: list[dict[str, Any]] = Field(
+        default_factory=list, description="Animation keyframe dicts for the emotion."
+    )

--- a/src/nanobot_runtime/services/hooks/tts/protocols.py
+++ b/src/nanobot_runtime/services/hooks/tts/protocols.py
@@ -1,0 +1,44 @@
+"""Injected-dependency protocols for the TTS pipeline."""
+
+from typing import Any, Callable, Protocol
+
+
+class SentenceChunker(Protocol):
+    """Protocol for streaming sentence boundary detectors."""
+
+    def feed(self, delta: str) -> list[str]: ...
+    def flush(self) -> str | None: ...
+
+
+class TextPreprocessor(Protocol):
+    """Protocol for text cleanup and emotion-tag extraction."""
+
+    def process(self, sentence: str) -> tuple[str, str | None]:
+        """Return (clean_text_for_display, emotion_tag_or_None)."""
+
+
+class EmotionMapper(Protocol):
+    """Protocol for mapping emotion tags to animation keyframes."""
+
+    def map(self, emotion: str | None) -> list[dict[str, Any]]: ...
+
+
+class TTSSynthesizer(Protocol):
+    """Protocol for async TTS synthesis backends."""
+
+    async def synthesize(
+        self, text: str, *, reference_id: str | None = None
+    ) -> str | None:
+        """Return base64-encoded audio (wav) or None on failure.
+
+        ``reference_id`` is an optional per-call voice override. ``None``
+        means "use the synthesizer's default"; an empty string forces no
+        reference even when the synthesizer has a baked-in default.
+        """
+
+
+# Resolves a session_key (``"desktop_mate:<chat_id>"``-style) to the voice
+# to use for that session, or ``None`` to fall back to the synthesizer's
+# default. The hook calls this *once per sentence dispatch*, so the resolver
+# may consult mutable channel state without stale-cache concerns.
+ReferenceIdResolver = Callable[[str | None], str | None]

--- a/src/nanobot_runtime/services/proactive/__init__.py
+++ b/src/nanobot_runtime/services/proactive/__init__.py
@@ -1,2 +1,5 @@
 """Proactive (agent-initiated) features."""
-from nanobot_runtime.services.proactive.installer import install_idle_asyncio_task
+
+from nanobot_runtime.services.proactive.installer import (
+    install_idle_asyncio_task as install_idle_asyncio_task,
+)

--- a/src/nanobot_runtime/services/proactive/installer.py
+++ b/src/nanobot_runtime/services/proactive/installer.py
@@ -9,6 +9,7 @@ Two install paths are exposed:
 
 Both are imported by the gateway launcher; only one should run per process.
 """
+
 import asyncio
 from datetime import datetime
 from typing import Any, Callable

--- a/src/nanobot_runtime/services/proactive/scanner.py
+++ b/src/nanobot_runtime/services/proactive/scanner.py
@@ -18,6 +18,7 @@ Dispatch path: scanner publishes a synthesized ``InboundMessage`` with
 OutboundMessage — identical to a real user message, so DesktopMateChannel
 streaming and TTS chunk routing work without proactive-specific glue.
 """
+
 from datetime import datetime
 from typing import Any, Callable, Protocol
 from zoneinfo import ZoneInfo
@@ -86,14 +87,14 @@ class IdleScanner:
         minutes = _minutes_between(fresh_updated, now)
         prompt = self._config.idle_prompt.format(minutes=minutes)
         try:
-            await self._dispatch_nudge(key=key, channel=channel, chat_id=chat_id, prompt=prompt)
+            await self._dispatch_nudge(
+                key=key, channel=channel, chat_id=chat_id, prompt=prompt
+            )
             logger.info("Idle nudge dispatched: session={} idle={}m", key, minutes)
         except Exception:
             logger.exception("Idle nudge failed for {}", key)
 
-    def _select_target(
-        self, now: datetime
-    ) -> tuple[str, str, str, datetime] | None:
+    def _select_target(self, now: datetime) -> tuple[str, str, str, datetime] | None:
         """Pick the most-recently-updated allowlisted session that passes every gate.
 
         Returns ``(session_key, channel, chat_id, fresh_updated_at)`` or ``None``.

--- a/src/nanobot_runtime/services/tts/__init__.py
+++ b/src/nanobot_runtime/services/tts/__init__.py
@@ -5,7 +5,7 @@ These modules implement the Protocols declared in
 EmotionMapper, TTSSynthesizer) using logic ported from DesktopMatePlus.
 """
 
-from nanobot_runtime.services.tts.chunker import SentenceChunker
-from nanobot_runtime.services.tts.emotion_mapper import EmotionMapper
-from nanobot_runtime.clients.irodori import IrodoriClient
-from nanobot_runtime.services.tts.preprocessor import Preprocessor
+from nanobot_runtime.services.tts.chunker import SentenceChunker as SentenceChunker
+from nanobot_runtime.services.tts.emotion_mapper import EmotionMapper as EmotionMapper
+from nanobot_runtime.clients.irodori import IrodoriClient as IrodoriClient
+from nanobot_runtime.services.tts.preprocessor import Preprocessor as Preprocessor

--- a/src/nanobot_runtime/services/tts/modes.py
+++ b/src/nanobot_runtime/services/tts/modes.py
@@ -17,6 +17,7 @@ Channels not listed default to the value of ``default:`` (which itself
 defaults to ``none`` if absent). Unknown mode strings raise ``ValueError``
 at boot so an operator typo fails loud.
 """
+
 from enum import Enum
 from pathlib import Path
 
@@ -129,10 +130,6 @@ def load_channel_modes(path: str | Path) -> ChannelModeMap:
             "delivery pipeline is implemented yet — those channels will "
             "receive no audio (silently equivalent to NONE).",
             p,
-            (
-                f"channels {attachment_channels}"
-                if attachment_channels
-                else "default"
-            ),
+            (f"channels {attachment_channels}" if attachment_channels else "default"),
         )
     return result

--- a/src/nanobot_runtime/services/tts/preprocessor.py
+++ b/src/nanobot_runtime/services/tts/preprocessor.py
@@ -43,7 +43,9 @@ class Preprocessor:
     """Clean TTS-bound sentence text and extract first known emotion emoji."""
 
     def __init__(self, known_emojis: frozenset[str] | None = None) -> None:
-        self.known_emojis = known_emojis if known_emojis is not None else _DEFAULT_EMOJI_SET
+        self.known_emojis = (
+            known_emojis if known_emojis is not None else _DEFAULT_EMOJI_SET
+        )
         self._cleanup_patterns: list[re.Pattern[str]] = [
             re.compile(r"\*[^*]*\*"),
             re.compile(r"\[[^\]]*\]"),

--- a/tests/clients/test_desktop_mate_rest.py
+++ b/tests/clients/test_desktop_mate_rest.py
@@ -5,13 +5,13 @@ filter and the channel's static ``?token=`` auth (instead of the TTL pool).
 These unit tests exercise ``_dispatch_http`` directly with fake requests
 and a fake SessionManager — no real socket binding.
 """
+
 from __future__ import annotations
 
 import asyncio
 import json
 from typing import Any
 
-import pytest
 
 from nanobot_runtime.services.channels.desktop_mate import (
     DesktopMateChannel,
@@ -19,9 +19,7 @@ from nanobot_runtime.services.channels.desktop_mate import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Fakes
-# ---------------------------------------------------------------------------
+# ── Fakes ────────────────────────────────────────────────────────────────────
 
 
 class FakeHeaders(dict):
@@ -66,9 +64,7 @@ class FakeSessionManager:
         return key in self._deletable
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# ── Helpers ──────────────────────────────────────────────────────────────────
 
 
 def _make_channel(
@@ -89,12 +85,14 @@ def _body_json(response: Any) -> dict[str, Any]:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+    return (
+        asyncio.get_event_loop().run_until_complete(coro)
+        if False
+        else asyncio.run(coro)
+    )
 
 
-# ---------------------------------------------------------------------------
-# Dispatch routing
-# ---------------------------------------------------------------------------
+# ── Dispatch routing ─────────────────────────────────────────────────────────
 
 
 def test_dispatch_unknown_path_returns_404():
@@ -123,22 +121,42 @@ def test_dispatch_non_upgrade_to_ws_path_is_404():
     assert resp.status_code == 404
 
 
-# ---------------------------------------------------------------------------
-# /api/sessions (list)
-# ---------------------------------------------------------------------------
+# ── /api/sessions (list) ─────────────────────────────────────────────────────
 
 
 def test_sessions_list_filters_prefix_and_strips_path():
     sm = FakeSessionManager(
         sessions=[
-            {"key": "desktop_mate:abc", "created_at": "t1", "updated_at": "t2", "path": "/x/abc.jsonl"},
-            {"key": "desktop_mate:def", "created_at": "t3", "updated_at": "t4", "path": "/x/def.jsonl"},
-            {"key": "websocket:foo", "created_at": "t5", "updated_at": "t6", "path": "/x/foo.jsonl"},
-            {"key": "slack:C1:1.0", "created_at": "t7", "updated_at": "t8", "path": "/x/s.jsonl"},
+            {
+                "key": "desktop_mate:abc",
+                "created_at": "t1",
+                "updated_at": "t2",
+                "path": "/x/abc.jsonl",
+            },
+            {
+                "key": "desktop_mate:def",
+                "created_at": "t3",
+                "updated_at": "t4",
+                "path": "/x/def.jsonl",
+            },
+            {
+                "key": "websocket:foo",
+                "created_at": "t5",
+                "updated_at": "t6",
+                "path": "/x/foo.jsonl",
+            },
+            {
+                "key": "slack:C1:1.0",
+                "created_at": "t7",
+                "updated_at": "t8",
+                "path": "/x/s.jsonl",
+            },
         ],
     )
     ch = _make_channel(session_manager=sm)
-    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret")))
+    resp = asyncio.run(
+        ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret"))
+    )
     assert resp.status_code == 200
     data = _body_json(resp)
     keys = [s["key"] for s in data["sessions"]]
@@ -155,7 +173,9 @@ def test_sessions_list_401_when_token_missing():
 
 def test_sessions_list_401_when_token_wrong():
     ch = _make_channel(session_manager=FakeSessionManager())
-    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=bogus")))
+    resp = asyncio.run(
+        ch._dispatch_http(None, FakeRequest("/api/sessions?token=bogus"))
+    )
     assert resp.status_code == 401
 
 
@@ -169,7 +189,9 @@ def test_sessions_list_accepts_bearer_header():
 
 def test_sessions_list_503_when_manager_missing():
     ch = _make_channel(session_manager=None)
-    resp = asyncio.run(ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret")))
+    resp = asyncio.run(
+        ch._dispatch_http(None, FakeRequest("/api/sessions?token=secret"))
+    )
     assert resp.status_code == 503
 
 
@@ -185,9 +207,7 @@ def test_sessions_list_allows_all_when_no_token_configured():
     assert resp.status_code == 200
 
 
-# ---------------------------------------------------------------------------
-# /api/sessions/{key}/messages (read)
-# ---------------------------------------------------------------------------
+# ── /api/sessions/{key}/messages (read) ──────────────────────────────────────
 
 
 def test_session_messages_happy_path():
@@ -254,16 +274,12 @@ def test_session_messages_404_when_not_found():
 def test_session_messages_401_no_token():
     ch = _make_channel(session_manager=FakeSessionManager())
     resp = asyncio.run(
-        ch._dispatch_http(
-            None, FakeRequest("/api/sessions/desktop_mate:x/messages")
-        )
+        ch._dispatch_http(None, FakeRequest("/api/sessions/desktop_mate:x/messages"))
     )
     assert resp.status_code == 401
 
 
-# ---------------------------------------------------------------------------
-# /api/sessions/{key}/delete
-# ---------------------------------------------------------------------------
+# ── /api/sessions/{key}/delete ───────────────────────────────────────────────
 
 
 def test_session_delete_true():

--- a/tests/clients/test_irodori.py
+++ b/tests/clients/test_irodori.py
@@ -2,6 +2,7 @@
 
 Uses pytest_httpx's `httpx_mock` fixture to stub httpx.AsyncClient.
 """
+
 from __future__ import annotations
 
 import base64
@@ -57,9 +58,7 @@ async def test_empty_text_short_circuits_without_http_call(
     assert httpx_mock.get_requests() == []
 
 
-async def test_request_error_returns_none(
-    httpx_mock: HTTPXMock, base_url: str
-) -> None:
+async def test_request_error_returns_none(httpx_mock: HTTPXMock, base_url: str) -> None:
     httpx_mock.add_exception(httpx.ConnectError("refused"))
     client = IrodoriClient(base_url=base_url)
     assert await client.synthesize("Hello.") is None
@@ -149,7 +148,9 @@ async def test_per_call_reference_id_overrides_constructor_default(
     # Constructor sets a *different* reference_id ("alice") that does not
     # exist on disk — if synthesize used it, it would fail-closed and return
     # None without making the HTTP call. Per-call override must win.
-    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    client = IrodoriClient(
+        base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path
+    )
     result = await client.synthesize("Hi.", reference_id="bob")
     assert result == base64.b64encode(b"ok").decode("utf-8")
 
@@ -174,7 +175,9 @@ async def test_per_call_reference_id_none_falls_back_to_constructor(
         status_code=200,
     )
 
-    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    client = IrodoriClient(
+        base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path
+    )
     result = await client.synthesize("Hi.")  # no per-call override
     assert result == base64.b64encode(b"ok").decode("utf-8")
     assert b"reference_audio" in httpx_mock.get_requests()[0].content
@@ -195,7 +198,9 @@ async def test_per_call_reference_id_empty_string_disables_baked_in(
         status_code=200,
     )
 
-    client = IrodoriClient(base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path)
+    client = IrodoriClient(
+        base_url=base_url, reference_id="alice", ref_audio_dir=tmp_path
+    )
     result = await client.synthesize("Hi.", reference_id="")
     assert result == base64.b64encode(b"ok").decode("utf-8")
     assert b"reference_audio" not in httpx_mock.get_requests()[0].content

--- a/tests/clients/test_ltm_integration.py
+++ b/tests/clients/test_ltm_integration.py
@@ -3,6 +3,7 @@
 Requires a running ltm-mcp at http://127.0.0.1:7777/mcp/ (see
 agents/mcp_servers/ltm/).
 """
+
 from __future__ import annotations
 
 import pytest
@@ -24,7 +25,9 @@ async def test_roundtrip_add_search_delete_via_adapter() -> None:
     )
     assert "results" in add, f"add_memory should return results key, got: {add}"
 
-    found = await client.search_memory(query="adapter integration", user_id=user_id, limit=5)
+    found = await client.search_memory(
+        query="adapter integration", user_id=user_id, limit=5
+    )
     assert "results" in found
 
     # Cleanup

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,6 +22,7 @@ Run with:
 
 or individually (tests are not collected by default — see ``pyproject.toml``).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -29,7 +30,6 @@ import os
 import signal
 import socket
 import subprocess
-import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -37,9 +37,7 @@ from typing import Any
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Configuration discovery
-# ---------------------------------------------------------------------------
+# ── Configuration discovery ──────────────────────────────────────────────────
 
 
 def _repo_root() -> Path:
@@ -89,9 +87,7 @@ def _http_reachable(url: str, timeout: float = 2.0) -> bool:
         return False
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
+# ── Fixtures ─────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture(scope="session")
@@ -140,9 +136,7 @@ def backends_up(workspace: Path) -> None:
     checks.append(("Irodori TTS", _http_reachable(tts_url.rstrip("/") + "/")))
 
     # LTM MCP
-    ltm_url = (
-        cfg.get("tools", {}).get("mcpServers", {}).get("ltm", {}).get("url", "")
-    )
+    ltm_url = cfg.get("tools", {}).get("mcpServers", {}).get("ltm", {}).get("url", "")
     if ltm_url:
         checks.append(("LTM MCP", _http_reachable(ltm_url)))
 
@@ -221,9 +215,7 @@ def gateway(
         proc.wait(timeout=5)
 
 
-# ---------------------------------------------------------------------------
-# GatewayProcess helper
-# ---------------------------------------------------------------------------
+# ── GatewayProcess helper ────────────────────────────────────────────────────
 
 
 class GatewayProcess:
@@ -250,9 +242,7 @@ class GatewayProcess:
         return sum(1 for ln in self.log_snapshot().splitlines() if substring in ln)
 
 
-# ---------------------------------------------------------------------------
-# WebSocket helpers
-# ---------------------------------------------------------------------------
+# ── WebSocket helpers ────────────────────────────────────────────────────────
 
 
 class LiveClient:

--- a/tests/e2e/test_live_scenarios.py
+++ b/tests/e2e/test_live_scenarios.py
@@ -23,19 +23,17 @@ Scenario I (default-on guard) is covered by the in-process suite only
 
 Run: ``pytest tests/e2e/ -m e2e`` (not collected by default).
 """
+
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
 
 pytestmark = pytest.mark.e2e
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
+# ── Shared helpers ───────────────────────────────────────────────────────────
 
 
 SYNTHESIZE_LOG_MARKER = "IrodoriClient.synthesize:"
@@ -59,15 +57,16 @@ async def run_turn_and_drain(
     await client.drain(drain_seconds)
 
 
-# ---------------------------------------------------------------------------
-# Scenario A — new session full lifecycle
-# ---------------------------------------------------------------------------
+# ── Scenario A — new session full lifecycle ──────────────────────────────────
 
 
 async def test_a_new_session_full_lifecycle(gateway, live_client) -> None:
     client = await live_client(client_id="e2e-A")
     ready = await client.wait_for_event("ready", timeout=5.0)
-    assert isinstance(ready.get("connection_id"), str) and len(ready["connection_id"]) == 36
+    assert (
+        isinstance(ready.get("connection_id"), str)
+        and len(ready["connection_id"]) == 36
+    )
 
     await run_turn_and_drain(
         client,
@@ -84,9 +83,7 @@ async def test_a_new_session_full_lifecycle(gateway, live_client) -> None:
     assert events.count("tts_chunk") >= 1, events
 
 
-# ---------------------------------------------------------------------------
-# Scenario B — resumed session via `message` with explicit chat_id
-# ---------------------------------------------------------------------------
+# ── Scenario B — resumed session via `message` with explicit chat_id ─────────
 
 
 async def test_b_resumed_session_with_explicit_chat_id(gateway, live_client) -> None:
@@ -100,13 +97,15 @@ async def test_b_resumed_session_with_explicit_chat_id(gateway, live_client) -> 
     )
 
     frames = client.frames
-    chat_ids = {f.get("chat_id") for f in frames if "chat_id" in f and f.get("event") != "ready"}
-    assert chat_ids == {chat_id}, f"expected all non-ready frames on {chat_id}; got {chat_ids}"
+    chat_ids = {
+        f.get("chat_id") for f in frames if "chat_id" in f and f.get("event") != "ready"
+    }
+    assert chat_ids == {
+        chat_id
+    }, f"expected all non-ready frames on {chat_id}; got {chat_ids}"
 
 
-# ---------------------------------------------------------------------------
-# Scenario C — long response → ≥3 tts_chunks
-# ---------------------------------------------------------------------------
+# ── Scenario C — long response → ≥3 tts_chunks ───────────────────────────────
 
 
 async def test_c_long_response_yields_multiple_tts_chunks(gateway, live_client) -> None:
@@ -149,9 +148,7 @@ async def test_c_long_response_yields_multiple_tts_chunks(gateway, live_client) 
         expected += 1
 
 
-# ---------------------------------------------------------------------------
-# Scenario D — emotion emoji stripped in delta, preserved in tts_chunk
-# ---------------------------------------------------------------------------
+# ── Scenario D — emotion emoji stripped in delta, preserved in tts_chunk ─────
 
 
 async def test_d_emotion_emoji_round_trip(gateway, live_client) -> None:
@@ -162,13 +159,23 @@ async def test_d_emotion_emoji_round_trip(gateway, live_client) -> None:
     # short prompts but we tolerate variation.
     await run_turn_and_drain(
         client,
-        {"type": "new_chat", "content": "한 문장으로 기쁘게 인사해줘 (😊 이모지 포함).", "tts_enabled": True},
+        {
+            "type": "new_chat",
+            "content": "한 문장으로 기쁘게 인사해줘 (😊 이모지 포함).",
+            "tts_enabled": True,
+        },
         stream_end_timeout=45.0,
     )
 
-    delta_text = "".join(f.get("text", "") for f in client.frames if f.get("event") == "delta")
-    tts_texts = [f.get("text", "") for f in client.frames if f.get("event") == "tts_chunk"]
-    emotions = [f.get("emotion") for f in client.frames if f.get("event") == "tts_chunk"]
+    delta_text = "".join(
+        f.get("text", "") for f in client.frames if f.get("event") == "delta"
+    )
+    tts_texts = [
+        f.get("text", "") for f in client.frames if f.get("event") == "tts_chunk"
+    ]
+    emotions = [
+        f.get("emotion") for f in client.frames if f.get("event") == "tts_chunk"
+    ]
 
     # The LLM may or may not include the emoji on any given run — we only
     # assert the invariant WHEN an emoji shows up in TTS text.
@@ -179,13 +186,13 @@ async def test_d_emotion_emoji_round_trip(gateway, live_client) -> None:
         )
         assert "😊" in emotions, f"emotion tag should be set; got emotions={emotions}"
     else:
-        pytest.skip("Model did not emit the requested emoji on this run — "
-                    "scenario D invariant not testable; rerun.")
+        pytest.skip(
+            "Model did not emit the requested emoji on this run — "
+            "scenario D invariant not testable; rerun."
+        )
 
 
-# ---------------------------------------------------------------------------
-# Scenario E — parallel chats isolated
-# ---------------------------------------------------------------------------
+# ── Scenario E — parallel chats isolated ─────────────────────────────────────
 
 
 async def test_e_parallel_chats_are_isolated(gateway, live_client) -> None:
@@ -196,16 +203,28 @@ async def test_e_parallel_chats_are_isolated(gateway, live_client) -> None:
 
     # Fire both turns concurrently; each must only receive its own frames.
     await asyncio.gather(
-        client_a.send_json({"type": "new_chat", "content": "ping A", "tts_enabled": False}),
-        client_b.send_json({"type": "new_chat", "content": "ping B", "tts_enabled": False}),
+        client_a.send_json(
+            {"type": "new_chat", "content": "ping A", "tts_enabled": False}
+        ),
+        client_b.send_json(
+            {"type": "new_chat", "content": "ping B", "tts_enabled": False}
+        ),
     )
     await asyncio.gather(
         client_a.wait_for_event("stream_end", timeout=45.0),
         client_b.wait_for_event("stream_end", timeout=45.0),
     )
 
-    a_ids = {f.get("chat_id") for f in client_a.frames if "chat_id" in f and f.get("event") != "ready"}
-    b_ids = {f.get("chat_id") for f in client_b.frames if "chat_id" in f and f.get("event") != "ready"}
+    a_ids = {
+        f.get("chat_id")
+        for f in client_a.frames
+        if "chat_id" in f and f.get("event") != "ready"
+    }
+    b_ids = {
+        f.get("chat_id")
+        for f in client_b.frames
+        if "chat_id" in f and f.get("event") != "ready"
+    }
 
     # Each client sees exactly one chat_id (its own assigned one) and
     # they must differ.
@@ -214,9 +233,7 @@ async def test_e_parallel_chats_are_isolated(gateway, live_client) -> None:
     assert a_ids != b_ids, f"clients share chat_id {a_ids}; cross-talk"
 
 
-# ---------------------------------------------------------------------------
-# Scenario F — reconnect after WS close: same chat_id → history preserved
-# ---------------------------------------------------------------------------
+# ── Scenario F — reconnect after WS close: same chat_id → history preserved ──
 
 
 async def test_f_reconnect_preserves_session_history(gateway, live_client) -> None:
@@ -288,20 +305,20 @@ async def test_f_reconnect_preserves_session_history(gateway, live_client) -> No
 
     # Both connections must have seen frames only for this chat_id.
     a_ids = {
-        f.get("chat_id") for f in client_a.frames
+        f.get("chat_id")
+        for f in client_a.frames
         if "chat_id" in f and f.get("event") != "ready"
     }
     b_ids = {
-        f.get("chat_id") for f in client_b.frames
+        f.get("chat_id")
+        for f in client_b.frames
         if "chat_id" in f and f.get("event") != "ready"
     }
     assert a_ids == {chat_id}, a_ids
     assert b_ids == {chat_id}, b_ids
 
 
-# ---------------------------------------------------------------------------
-# Scenario G — URL ?tts=0 disables TTS entirely
-# ---------------------------------------------------------------------------
+# ── Scenario G — URL ?tts=0 disables TTS entirely ────────────────────────────
 
 
 async def test_g_url_tts_zero_skips_synth_and_frame(gateway, live_client) -> None:
@@ -326,9 +343,7 @@ async def test_g_url_tts_zero_skips_synth_and_frame(gateway, live_client) -> Non
     )
 
 
-# ---------------------------------------------------------------------------
-# Scenario H — inbound tts_enabled: false
-# ---------------------------------------------------------------------------
+# ── Scenario H — inbound tts_enabled: false ──────────────────────────────────
 
 
 async def test_h_inbound_tts_enabled_false(gateway, live_client) -> None:
@@ -352,9 +367,7 @@ async def test_h_inbound_tts_enabled_false(gateway, live_client) -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Scenario I — image intake (issue #8)
-# ---------------------------------------------------------------------------
+# ── Scenario I — image intake (issue #8) ─────────────────────────────────────
 
 
 # 1x1 transparent PNG, inline so the suite has no fixture file dependency.
@@ -365,7 +378,9 @@ _TINY_PNG_DATA_URL = (
 )
 
 
-async def test_i_inbound_image_reaches_multimodal_pipeline(gateway, live_client) -> None:
+async def test_i_inbound_image_reaches_multimodal_pipeline(
+    gateway, live_client
+) -> None:
     """Smoke: FE sends a ``data:image/png`` URL; gateway writes it to the
     desktop_mate media dir and the agent loop drives a normal turn to
     completion (stream_start → delta → stream_end).

--- a/tests/models/test_desktop_mate.py
+++ b/tests/models/test_desktop_mate.py
@@ -5,6 +5,7 @@ outbound frames (stream_start/delta/stream_end/tts_chunk) and inbound
 envelopes (new_chat/message). The channel implementation is expected to
 build these models and serialise with ``model_dump_json(exclude_none=True)``.
 """
+
 from __future__ import annotations
 
 import json
@@ -26,9 +27,7 @@ from nanobot_runtime.models.desktop_mate import (
 )
 
 
-# ---------------------------------------------------------------------------
-# Outbound — ready
-# ---------------------------------------------------------------------------
+# ── Outbound — ready ─────────────────────────────────────────────────────────
 
 
 def test_ready_frame_serialises_fully():
@@ -56,9 +55,7 @@ def test_ready_frame_event_is_literal():
         )
 
 
-# ---------------------------------------------------------------------------
-# Outbound — stream_start
-# ---------------------------------------------------------------------------
+# ── Outbound — stream_start ──────────────────────────────────────────────────
 
 
 def test_stream_start_minimal_omits_proactive():
@@ -79,9 +76,7 @@ def test_stream_start_event_is_literal():
         StreamStartFrame(event="stream_end", chat_id="chat-A")  # type: ignore[arg-type]
 
 
-# ---------------------------------------------------------------------------
-# Outbound — delta
-# ---------------------------------------------------------------------------
+# ── Outbound — delta ─────────────────────────────────────────────────────────
 
 
 def test_delta_minimal():
@@ -107,9 +102,7 @@ def test_delta_with_stream_id_and_proactive():
     }
 
 
-# ---------------------------------------------------------------------------
-# Outbound — stream_end
-# ---------------------------------------------------------------------------
+# ── Outbound — stream_end ────────────────────────────────────────────────────
 
 
 def test_stream_end_carries_full_content():
@@ -133,9 +126,7 @@ def test_stream_end_with_proactive():
     }
 
 
-# ---------------------------------------------------------------------------
-# Outbound — tts_chunk
-# ---------------------------------------------------------------------------
+# ── Outbound — tts_chunk ─────────────────────────────────────────────────────
 
 
 def test_tts_chunk_full_payload():
@@ -191,9 +182,7 @@ def test_tts_chunk_with_proactive():
     assert payload["proactive"] is True
 
 
-# ---------------------------------------------------------------------------
-# Inbound — new_chat / message discriminated union
-# ---------------------------------------------------------------------------
+# ── Inbound — new_chat / message discriminated union ─────────────────────────
 
 
 def test_parse_inbound_new_chat():
@@ -212,13 +201,15 @@ def test_parse_inbound_message_requires_chat_id():
 
 
 def test_parse_inbound_message_with_chat_id():
-    raw = json.dumps({
-        "type": "message",
-        "chat_id": "chat-42",
-        "content": "hi",
-        "tts_enabled": False,
-        "reference_id": "ref-1",
-    })
+    raw = json.dumps(
+        {
+            "type": "message",
+            "chat_id": "chat-42",
+            "content": "hi",
+            "tts_enabled": False,
+            "reference_id": "ref-1",
+        }
+    )
     env = parse_inbound(raw)
     assert isinstance(env, MessageFrame)
     assert env.chat_id == "chat-42"
@@ -268,9 +259,7 @@ def test_image_rejected_frame_with_chat_id():
 
 def test_inbound_envelope_is_tagged_union():
     # Positive control: InboundEnvelope should discriminate on `type`.
-    new_chat = InboundEnvelope.validate_python(
-        {"type": "new_chat", "content": "hello"}
-    )
+    new_chat = InboundEnvelope.validate_python({"type": "new_chat", "content": "hello"})
     assert isinstance(new_chat, NewChatFrame)
 
     msg = InboundEnvelope.validate_python(

--- a/tests/regression/harness.py
+++ b/tests/regression/harness.py
@@ -10,9 +10,9 @@ This gives deterministic, in-process regression coverage of the wire
 contract without depending on a running gateway or live LLM/TTS
 backends. See :mod:`tests.regression.test_scenarios` for the scenarios.
 """
+
 from __future__ import annotations
 
-import asyncio
 import json
 import uuid
 from dataclasses import dataclass, field
@@ -77,7 +77,9 @@ class RecordingSynthesizer:
         self.calls: list[str] = []
         self.ref_calls: list[str | None] = []
 
-    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
+    async def synthesize(
+        self, text: str, *, reference_id: str | None = None
+    ) -> str | None:
         self.calls.append(text)
         self.ref_calls.append(reference_id)
         # Short, fixed base64 so tests can assert the FULL tts_chunk

--- a/tests/regression/test_scenarios.py
+++ b/tests/regression/test_scenarios.py
@@ -3,13 +3,13 @@
 Each scenario exercises the channel + hook composition end-to-end in
 process. See :mod:`harness` for the simulation primitives.
 """
+
 from __future__ import annotations
 
 import json
 
-import pytest
 
-from .harness import FakeConnection, Harness, build_harness
+from .harness import FakeConnection, build_harness
 
 
 # =========================================================================
@@ -20,9 +20,11 @@ from .harness import FakeConnection, Harness, build_harness
 
 async def test_scenario_a_new_session_full_lifecycle() -> None:
     harness = build_harness()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
+        ]
+    )
 
     await harness.drive_inbound(conn)
     chat_id = next(iter(harness.channel._chat_conn.keys()))
@@ -49,14 +51,18 @@ async def test_scenario_a_new_session_full_lifecycle() -> None:
 
 async def test_scenario_b_resumed_session_uses_supplied_chat_id() -> None:
     harness = build_harness()
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-resume-42",
-            "content": "follow up",
-            "tts_enabled": True,
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-resume-42",
+                    "content": "follow up",
+                    "tts_enabled": True,
+                }
+            ),
+        ]
+    )
 
     await harness.drive_inbound(conn)
     assert harness.bus.inbound[0].chat_id == "chat-resume-42"
@@ -118,7 +124,9 @@ async def test_scenario_d_emotion_emoji_stripped_in_delta_preserved_in_tts() -> 
 
     assert delta_frames, "expected at least one delta frame"
     for f in delta_frames:
-        assert "😊" not in f["text"], f"emoji must be stripped from delta; got {f['text']!r}"
+        assert (
+            "😊" not in f["text"]
+        ), f"emoji must be stripped from delta; got {f['text']!r}"
 
     assert tts_frames, "expected a tts_chunk (synth fired)"
     # The original sentence text (with emoji) is passed to TTS —
@@ -127,9 +135,9 @@ async def test_scenario_d_emotion_emoji_stripped_in_delta_preserved_in_tts() -> 
     # recorded separately. Preprocessor currently keeps the emoji in
     # the cleaned text (it only strips *action*/[meta]), so tts_chunk.text
     # includes it.
-    assert any("😊" in f["text"] for f in tts_frames), (
-        f"emoji must be preserved in tts_chunk.text; got texts={[f['text'] for f in tts_frames]}"
-    )
+    assert any(
+        "😊" in f["text"] for f in tts_frames
+    ), f"emoji must be preserved in tts_chunk.text; got texts={[f['text'] for f in tts_frames]}"
     assert tts_frames[0]["emotion"] == "😊"
 
 
@@ -165,9 +173,11 @@ async def test_scenario_f_reconnect_with_existing_chat_id() -> None:
     harness = build_harness()
 
     # First connection: new_chat creates a chat_id.
-    conn1 = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "first"}),
-    ])
+    conn1 = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "first"}),
+        ]
+    )
     await harness.drive_inbound(conn1)
     original_chat_id = harness.bus.inbound[0].chat_id
     await harness.simulate_agent_turn(original_chat_id, deltas=["reply one."])
@@ -177,22 +187,27 @@ async def test_scenario_f_reconnect_with_existing_chat_id() -> None:
     assert original_chat_id not in harness.channel._chat_conn
 
     # Reconnect with the same chat_id via `message`.
-    conn2 = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": original_chat_id,
-            "content": "second",
-        }),
-    ])
+    conn2 = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": original_chat_id,
+                    "content": "second",
+                }
+            ),
+        ]
+    )
     await harness.drive_inbound(conn2)
     assert harness.bus.inbound[-1].chat_id == original_chat_id
     await harness.simulate_agent_turn(original_chat_id, deltas=["reply two."])
 
     # Post-reconnect reply must land on conn2, not conn1.
     conn2_frames = harness.frames(conn2)
-    assert any("reply two" in f.get("content", "") or "reply" in f.get("text", "") for f in conn2_frames), (
-        f"expected reply frames on conn2; got {conn2_frames}"
-    )
+    assert any(
+        "reply two" in f.get("content", "") or "reply" in f.get("text", "")
+        for f in conn2_frames
+    ), f"expected reply frames on conn2; got {conn2_frames}"
 
 
 # =========================================================================
@@ -203,9 +218,11 @@ async def test_scenario_f_reconnect_with_existing_chat_id() -> None:
 
 async def test_scenario_g_tts_off_via_url_override_skips_synth_and_frame() -> None:
     harness = build_harness()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
+        ]
+    )
     # URL override wins over the per-message flag.
     harness.tts_override_tts_zero(conn)
     await harness.drive_inbound(conn)
@@ -213,9 +230,9 @@ async def test_scenario_g_tts_off_via_url_override_skips_synth_and_frame() -> No
 
     await harness.simulate_agent_turn(chat_id, deltas=["Hello there."])
 
-    assert harness.synth.calls == [], (
-        f"synthesizer must not be invoked when URL ?tts=0; got {harness.synth.calls}"
-    )
+    assert (
+        harness.synth.calls == []
+    ), f"synthesizer must not be invoked when URL ?tts=0; got {harness.synth.calls}"
     events = harness.events(conn)
     assert "tts_chunk" not in events, events
 
@@ -227,17 +244,19 @@ async def test_scenario_g_tts_off_via_url_override_skips_synth_and_frame() -> No
 
 async def test_scenario_h_tts_off_via_inbound_flag_skips_synth_and_frame() -> None:
     harness = build_harness()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": False}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": False}),
+        ]
+    )
     await harness.drive_inbound(conn)
     chat_id = next(iter(harness.channel._chat_conn.keys()))
 
     await harness.simulate_agent_turn(chat_id, deltas=["Hello there."])
 
-    assert harness.synth.calls == [], (
-        f"synthesizer must not be invoked when tts_enabled=False; got {harness.synth.calls}"
-    )
+    assert (
+        harness.synth.calls == []
+    ), f"synthesizer must not be invoked when tts_enabled=False; got {harness.synth.calls}"
     events = harness.events(conn)
     assert "tts_chunk" not in events, events
 
@@ -250,9 +269,11 @@ async def test_scenario_h_tts_off_via_inbound_flag_skips_synth_and_frame() -> No
 
 async def test_scenario_i_tts_default_enabled_when_flag_absent() -> None:
     harness = build_harness()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi"}),  # no tts_enabled
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi"}),  # no tts_enabled
+        ]
+    )
     await harness.drive_inbound(conn)
     chat_id = next(iter(harness.channel._chat_conn.keys()))
 

--- a/tests/services/channels/test_desktop_mate.py
+++ b/tests/services/channels/test_desktop_mate.py
@@ -4,6 +4,7 @@ All unit tests use a fake `_WSConnection` (capturing sent frames in an
 in-memory list) to exercise the channel without binding a real socket.
 The last test binds a real ephemeral port to cover start()/stop() lifecycle.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -24,9 +25,7 @@ from nanobot_runtime.services.hooks.tts import TTSChunk
 from nanobot_runtime.services.tts.modes import ChannelModeMap, TTSMode
 
 
-# ---------------------------------------------------------------------------
-# Fakes
-# ---------------------------------------------------------------------------
+# ── Fakes ────────────────────────────────────────────────────────────────────
 
 
 class FakeConnection:
@@ -36,7 +35,11 @@ class FakeConnection:
     iterating .inbox (a list of strings) asynchronously.
     """
 
-    def __init__(self, inbox: list[str] | None = None, remote: tuple[str, int] = ("127.0.0.1", 12345)):
+    def __init__(
+        self,
+        inbox: list[str] | None = None,
+        remote: tuple[str, int] = ("127.0.0.1", 12345),
+    ):
         self.sent: list[str] = []
         self.inbox: list[str] = list(inbox or [])
         self.remote_address = remote
@@ -58,6 +61,7 @@ class FakeConnection:
         async def _gen():
             for item in list(self.inbox):
                 yield item
+
         return _gen()
 
 
@@ -73,7 +77,12 @@ class FakeBus:
         self.outbound.append(msg)
 
 
-def _make_channel(*, token: str = "secret", allow_from: list[str] | None = None, emotions: set[str] | None = None) -> tuple[DesktopMateChannel, FakeBus]:
+def _make_channel(
+    *,
+    token: str = "secret",
+    allow_from: list[str] | None = None,
+    emotions: set[str] | None = None,
+) -> tuple[DesktopMateChannel, FakeBus]:
     bus = FakeBus()
     config = DesktopMateConfig(
         token=token,
@@ -93,9 +102,7 @@ def _decode_frames(conn: FakeConnection) -> list[dict[str, Any]]:
     return [json.loads(raw) for raw in conn.sent]
 
 
-# ---------------------------------------------------------------------------
-# 1. stream_start via send()
-# ---------------------------------------------------------------------------
+# ── 1. stream_start via send() ───────────────────────────────────────────────
 
 
 async def test_send_stream_start_emits_event_frame():
@@ -118,9 +125,7 @@ async def test_send_stream_start_emits_event_frame():
     assert frames == [{"event": "stream_start", "chat_id": "chat-A"}]
 
 
-# ---------------------------------------------------------------------------
-# 2. send_delta strips emotion emojis
-# ---------------------------------------------------------------------------
+# ── 2. send_delta strips emotion emojis ──────────────────────────────────────
 
 
 async def test_send_delta_strips_emotion_emojis():
@@ -144,9 +149,7 @@ async def test_send_delta_strips_emotion_emojis():
     assert frames[1]["stream_id"] == "s-1"
 
 
-# ---------------------------------------------------------------------------
-# 3. send_tts_chunk emits full 6-field frame
-# ---------------------------------------------------------------------------
+# ── 3. send_tts_chunk emits full 6-field frame ───────────────────────────────
 
 
 async def test_send_tts_chunk_emits_full_frame():
@@ -155,7 +158,9 @@ async def test_send_tts_chunk_emits_full_frame():
     channel._attach("chat-A", conn)
 
     # First, register a stream so the channel knows where TTS chunks go.
-    await channel.send_delta("chat-A", "warmup", {"_stream_delta": True, "_stream_id": "s-1"})
+    await channel.send_delta(
+        "chat-A", "warmup", {"_stream_delta": True, "_stream_id": "s-1"}
+    )
     conn.sent.clear()
 
     chunk = TTSChunk(
@@ -168,20 +173,20 @@ async def test_send_tts_chunk_emits_full_frame():
     await channel.send_tts_chunk(chunk)
 
     frames = _decode_frames(conn)
-    assert frames == [{
-        "event": "tts_chunk",
-        "chat_id": "chat-A",
-        "sequence": 2,
-        "text": "hello there",
-        "audio_base64": "AAAA",
-        "emotion": "happy",
-        "keyframes": [{"duration": 0.3, "targets": {"expression": 1.0}}],
-    }]
+    assert frames == [
+        {
+            "event": "tts_chunk",
+            "chat_id": "chat-A",
+            "sequence": 2,
+            "text": "hello there",
+            "audio_base64": "AAAA",
+            "emotion": "happy",
+            "keyframes": [{"duration": 0.3, "targets": {"expression": 1.0}}],
+        }
+    ]
 
 
-# ---------------------------------------------------------------------------
-# 4. Frame ordering: deltas × 3, tts_chunks × 2, stream_end preserved
-# ---------------------------------------------------------------------------
+# ── 4. Frame ordering: deltas × 3, tts_chunks × 2, stream_end preserved ──────
 
 
 async def test_frame_ordering_delta_tts_stream_end():
@@ -194,8 +199,12 @@ async def test_frame_ordering_delta_tts_stream_end():
     await channel.send_delta("chat-A", "two ", meta)
     await channel.send_delta("chat-A", "three", meta)
 
-    await channel.send_tts_chunk(TTSChunk(sequence=0, text="one.", audio_base64=None, emotion=None, keyframes=[]))
-    await channel.send_tts_chunk(TTSChunk(sequence=1, text="two.", audio_base64=None, emotion=None, keyframes=[]))
+    await channel.send_tts_chunk(
+        TTSChunk(sequence=0, text="one.", audio_base64=None, emotion=None, keyframes=[])
+    )
+    await channel.send_tts_chunk(
+        TTSChunk(sequence=1, text="two.", audio_base64=None, emotion=None, keyframes=[])
+    )
 
     end_msg = OutboundMessage(
         channel="desktop_mate",
@@ -226,9 +235,7 @@ async def test_frame_ordering_delta_tts_stream_end():
     }
 
 
-# ---------------------------------------------------------------------------
-# 4a. send() suppresses iteration-boundary OutboundMessages (no _stream_end)
-# ---------------------------------------------------------------------------
+# ── 4a. send() suppresses iteration-boundary OutboundMessages (no _stream_end)
 
 
 async def test_send_suppresses_intermediate_iteration_outbound():
@@ -273,9 +280,7 @@ async def test_send_with_explicit_stream_end_still_emits():
     assert len(frames) == 1 and frames[0]["event"] == "stream_end"
 
 
-# ---------------------------------------------------------------------------
-# 4a-2. send_delta() drops empty _stream_end on a brand-new stream_id
-# ---------------------------------------------------------------------------
+# ── 4a-2. send_delta() drops empty _stream_end on a brand-new stream_id ──────
 
 
 async def test_send_delta_drops_empty_stream_end_on_new_stream_id():
@@ -324,9 +329,7 @@ async def test_send_delta_empty_stream_end_on_existing_stream_still_emits():
     assert len(frames) == 1 and frames[0]["event"] == "stream_end"
 
 
-# ---------------------------------------------------------------------------
-# 4b. stream_start auto-emitted on first delta with a new stream_id
-# ---------------------------------------------------------------------------
+# ── 4b. stream_start auto-emitted on first delta with a new stream_id ────────
 
 
 async def test_first_delta_auto_emits_stream_start():
@@ -359,9 +362,7 @@ async def test_second_delta_same_stream_does_not_repeat_start():
     assert events == ["stream_start", "delta", "delta"]
 
 
-# ---------------------------------------------------------------------------
-# 4c. tts_chunk arriving AFTER stream_end still routes (TTS Barrier race)
-# ---------------------------------------------------------------------------
+# ── 4c. tts_chunk arriving AFTER stream_end still routes (TTS Barrier race) ──
 
 
 async def test_tts_chunk_after_stream_end_still_routes():
@@ -377,22 +378,26 @@ async def test_tts_chunk_after_stream_end_still_routes():
     # Full stream lifecycle: deltas then _stream_end.
     meta = {"_stream_delta": True, "_stream_id": "s-late"}
     await channel.send_delta("chat-A", "hello", meta)
-    await channel.send(OutboundMessage(
-        channel="desktop_mate",
-        chat_id="chat-A",
-        content="hello",
-        metadata={"_stream_end": True, "_stream_id": "s-late"},
-    ))
+    await channel.send(
+        OutboundMessage(
+            channel="desktop_mate",
+            chat_id="chat-A",
+            content="hello",
+            metadata={"_stream_end": True, "_stream_id": "s-late"},
+        )
+    )
 
     # Now (simulating the barrier race) a tts_chunk synthesised during
     # the turn arrives.
-    await channel.send_tts_chunk(TTSChunk(
-        sequence=0,
-        text="hello",
-        audio_base64="AAAA",
-        emotion=None,
-        keyframes=[],
-    ))
+    await channel.send_tts_chunk(
+        TTSChunk(
+            sequence=0,
+            text="hello",
+            audio_base64="AAAA",
+            emotion=None,
+            keyframes=[],
+        )
+    )
 
     frames = _decode_frames(conn)
     events = [f["event"] for f in frames]
@@ -402,16 +407,16 @@ async def test_tts_chunk_after_stream_end_still_routes():
     assert tts_frame["chat_id"] == "chat-A"
 
 
-# ---------------------------------------------------------------------------
-# 5. Inbound parsing: new_chat + message
-# ---------------------------------------------------------------------------
+# ── 5. Inbound parsing: new_chat + message ───────────────────────────────────
 
 
 async def test_inbound_new_chat_generates_chat_id_and_publishes():
     channel, bus = _make_channel()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hello", "tts_enabled": True}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hello", "tts_enabled": True}),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -426,9 +431,18 @@ async def test_inbound_new_chat_generates_chat_id_and_publishes():
 
 async def test_inbound_message_uses_supplied_chat_id():
     channel, bus = _make_channel()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "message", "chat_id": "chat-42", "content": "hi", "tts_enabled": False}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-42",
+                    "content": "hi",
+                    "tts_enabled": False,
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -439,9 +453,7 @@ async def test_inbound_message_uses_supplied_chat_id():
     assert inbound.metadata.get("tts_enabled") is False
 
 
-# ---------------------------------------------------------------------------
-# 6. Auth: bad token rejected
-# ---------------------------------------------------------------------------
+# ── 6. Auth: bad token rejected ──────────────────────────────────────────────
 
 
 async def test_bad_token_is_rejected():
@@ -469,9 +481,7 @@ async def test_handshake_closes_connection_with_4003_on_bad_token():
     assert conn.close_code == 4003
 
 
-# ---------------------------------------------------------------------------
-# 7. Proactive flag passthrough
-# ---------------------------------------------------------------------------
+# ── 7. Proactive flag passthrough ────────────────────────────────────────────
 
 
 async def test_proactive_flag_included_in_stream_start():
@@ -502,22 +512,24 @@ async def test_proactive_flag_included_in_delta_and_tts_and_end():
         {"_stream_delta": True, "_stream_id": "s-1", "proactive": True},
     )
     # Register current stream for tts routing with proactive flag
-    await channel.send_tts_chunk(TTSChunk(sequence=0, text="hi", audio_base64=None, emotion=None, keyframes=[]))
+    await channel.send_tts_chunk(
+        TTSChunk(sequence=0, text="hi", audio_base64=None, emotion=None, keyframes=[])
+    )
 
-    await channel.send(OutboundMessage(
-        channel="desktop_mate",
-        chat_id="chat-A",
-        content="hi",
-        metadata={"_stream_end": True, "_stream_id": "s-1", "proactive": True},
-    ))
+    await channel.send(
+        OutboundMessage(
+            channel="desktop_mate",
+            chat_id="chat-A",
+            content="hi",
+            metadata={"_stream_end": True, "_stream_id": "s-1", "proactive": True},
+        )
+    )
 
     frames = _decode_frames(conn)
     assert all(f.get("proactive") is True for f in frames), frames
 
 
-# ---------------------------------------------------------------------------
-# 8. start()/stop() lifecycle on ephemeral port
-# ---------------------------------------------------------------------------
+# ── 8. start()/stop() lifecycle on ephemeral port ────────────────────────────
 
 
 async def test_start_stop_lifecycle_binds_and_cleans_up():
@@ -536,9 +548,7 @@ async def test_start_stop_lifecycle_binds_and_cleans_up():
     assert channel.is_running is False
 
 
-# ---------------------------------------------------------------------------
-# 9. Handshake success emits ReadyFrame
-# ---------------------------------------------------------------------------
+# ── 9. Handshake success emits ReadyFrame ────────────────────────────────────
 
 
 async def test_successful_handshake_emits_ready_frame():
@@ -563,9 +573,7 @@ async def test_successful_handshake_emits_ready_frame():
     assert frame["server_time"] > 0
 
 
-# ---------------------------------------------------------------------------
-# 10. Config defaults include ping_interval + max_message_bytes (6MB)
-# ---------------------------------------------------------------------------
+# ── 10. Config defaults include ping_interval + max_message_bytes (6MB) ──────
 
 
 def test_desktop_mate_config_defaults_keepalive_and_max_size():
@@ -576,23 +584,21 @@ def test_desktop_mate_config_defaults_keepalive_and_max_size():
     assert cfg.max_message_bytes == 60 * 1024 * 1024
 
 
-# ---------------------------------------------------------------------------
-# 11. serve() receives the keepalive + max_size kwargs
-# ---------------------------------------------------------------------------
+# ── 11. serve() receives the keepalive + max_size kwargs ─────────────────────
 
 
-# ---------------------------------------------------------------------------
-# 11b. tts_enabled switch (per-message + URL override)
-# ---------------------------------------------------------------------------
+# ── 11b. tts_enabled switch (per-message + URL override) ─────────────────────
 
 
 async def test_new_chat_with_tts_disabled_drops_tts_chunk():
     """FE sends ``tts_enabled: false`` in new_chat → channel must not emit
     any tts_chunk for that chat, even if synthesis produces one."""
     channel, _ = _make_channel()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": False}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": False}),
+        ]
+    )
     await channel._connection_loop(conn, sender_id="user-1")
     chat_id = next(iter(channel._chat_conn.keys()))
 
@@ -604,10 +610,15 @@ async def test_new_chat_with_tts_disabled_drops_tts_chunk():
     )
     conn.sent.clear()
 
-    await channel.send_tts_chunk(TTSChunk(
-        sequence=0, text="hi", audio_base64="AAAA",
-        emotion=None, keyframes=[],
-    ))
+    await channel.send_tts_chunk(
+        TTSChunk(
+            sequence=0,
+            text="hi",
+            audio_base64="AAAA",
+            emotion=None,
+            keyframes=[],
+        )
+    )
 
     events = [f.get("event") for f in _decode_frames(conn)]
     assert "tts_chunk" not in events, f"tts_chunk should be suppressed; got {events}"
@@ -617,9 +628,11 @@ async def test_message_defaults_tts_enabled_true():
     """Absent ``tts_enabled`` in an inbound message must default to True
     so existing clients aren't silently muted."""
     channel, _ = _make_channel()
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi"}),  # no tts_enabled
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi"}),  # no tts_enabled
+        ]
+    )
     await channel._connection_loop(conn, sender_id="user-1")
     chat_id = next(iter(channel._chat_conn.keys()))
 
@@ -630,10 +643,15 @@ async def test_message_defaults_tts_enabled_true():
     )
     conn.sent.clear()
 
-    await channel.send_tts_chunk(TTSChunk(
-        sequence=0, text="hi", audio_base64="AAAA",
-        emotion=None, keyframes=[],
-    ))
+    await channel.send_tts_chunk(
+        TTSChunk(
+            sequence=0,
+            text="hi",
+            audio_base64="AAAA",
+            emotion=None,
+            keyframes=[],
+        )
+    )
 
     events = [f.get("event") for f in _decode_frames(conn)]
     assert "tts_chunk" in events
@@ -656,9 +674,11 @@ async def test_url_override_tts_zero_disables_connection_wide(monkeypatch):
 
     # Attach a chat and simulate a message with ``tts_enabled: true`` —
     # URL override must win.
-    conn_inbox = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
-    ])
+    conn_inbox = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "tts_enabled": True}),
+        ]
+    )
     # Copy the override onto the per-test inbox connection.
     channel._apply_connection_tts_override(conn_inbox, {"tts": ["0"]})
     await channel._connection_loop(conn_inbox, sender_id="user-1")
@@ -671,10 +691,15 @@ async def test_url_override_tts_zero_disables_connection_wide(monkeypatch):
     )
     conn_inbox.sent.clear()
 
-    await channel.send_tts_chunk(TTSChunk(
-        sequence=0, text="hi", audio_base64="AAAA",
-        emotion=None, keyframes=[],
-    ))
+    await channel.send_tts_chunk(
+        TTSChunk(
+            sequence=0,
+            text="hi",
+            audio_base64="AAAA",
+            emotion=None,
+            keyframes=[],
+        )
+    )
 
     events = [f.get("event") for f in _decode_frames(conn_inbox)]
     assert "tts_chunk" not in events
@@ -683,9 +708,11 @@ async def test_url_override_tts_zero_disables_connection_wide(monkeypatch):
 async def test_url_tts_equals_one_is_a_noop():
     """``?tts=1`` (or absent) leaves the default path enabled."""
     channel, _ = _make_channel(token="")
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi"}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi"}),
+        ]
+    )
     channel._apply_connection_tts_override(conn, {"tts": ["1"]})
     await channel._connection_loop(conn, sender_id="user-1")
     chat_id = next(iter(channel._chat_conn.keys()))
@@ -697,18 +724,21 @@ async def test_url_tts_equals_one_is_a_noop():
     )
     conn.sent.clear()
 
-    await channel.send_tts_chunk(TTSChunk(
-        sequence=0, text="hi", audio_base64="AAAA",
-        emotion=None, keyframes=[],
-    ))
+    await channel.send_tts_chunk(
+        TTSChunk(
+            sequence=0,
+            text="hi",
+            audio_base64="AAAA",
+            emotion=None,
+            keyframes=[],
+        )
+    )
 
     events = [f.get("event") for f in _decode_frames(conn)]
     assert "tts_chunk" in events
 
 
-# ---------------------------------------------------------------------------
-# 12. __init__ accepts dict section (from nanobot.json via ChannelManager)
-# ---------------------------------------------------------------------------
+# ── 12. __init__ accepts dict section (from nanobot.json via ChannelManager) ─
 
 
 def test_init_accepts_dict_section_snake_case():
@@ -764,12 +794,12 @@ def test_init_loads_emotion_emojis_from_yaml_path(tmp_path):
     yaml_path = tmp_path / "tts_rules.yml"
     yaml_path.write_text(
         "emotion_motion_map:\n"
-        "  \"😊\":\n"
+        '  "😊":\n'
         "    keyframes:\n"
         "      - duration: 0.3\n"
         "        targets:\n"
         "          happy: 1.0\n"
-        "  \"😢\":\n"
+        '  "😢":\n'
         "    keyframes:\n"
         "      - duration: 0.3\n"
         "        targets:\n"
@@ -819,7 +849,6 @@ def test_init_ignores_unknown_section_keys():
 async def test_start_passes_ping_and_max_size_to_serve(monkeypatch):
     """start() must forward ping_interval / ping_timeout / max_size to
     websockets.serve() so the WS protocol handles keepalive for us."""
-    import nanobot_runtime.services.channels.desktop_mate as dm
 
     captured: dict[str, Any] = {}
 
@@ -949,7 +978,9 @@ class TestLazyChannelTTSSinkIsEnabled:
         sink = LazyChannelTTSSink(mode_map=streaming_only_map)
         assert sink.is_enabled("telegram:42:topic:7") is False
 
-    def test_session_key_none_uses_default_mode(self, streaming_only_map: ChannelModeMap):
+    def test_session_key_none_uses_default_mode(
+        self, streaming_only_map: ChannelModeMap
+    ):
         sink = LazyChannelTTSSink(mode_map=streaming_only_map)
         assert sink.is_enabled(None) is False  # default is NONE
 

--- a/tests/services/channels/test_desktop_mate_images.py
+++ b/tests/services/channels/test_desktop_mate_images.py
@@ -11,6 +11,7 @@ and does **not** publish to the bus.
 Uses the same ``FakeConnection`` + ``FakeBus`` shape as
 ``test_desktop_mate.py`` to keep the fixtures comparable.
 """
+
 from __future__ import annotations
 
 import base64
@@ -41,15 +42,12 @@ _TINY_PNG_BYTES = base64.b64decode(
 )
 _TINY_PNG_B64 = base64.b64encode(_TINY_PNG_BYTES).decode("ascii")
 TINY_PNG_DATA_URL = f"data:image/png;base64,{_TINY_PNG_B64}"
-TINY_JPG_DATA_URL = (
-    "data:image/jpeg;base64,"
-    + base64.b64encode(b"\xff\xd8\xff\xd9").decode("ascii")
-)
+TINY_JPG_DATA_URL = "data:image/jpeg;base64," + base64.b64encode(
+    b"\xff\xd8\xff\xd9"
+).decode("ascii")
 
 
-# ---------------------------------------------------------------------------
-# Fakes (mirror test_desktop_mate.py so fixtures read consistently)
-# ---------------------------------------------------------------------------
+# ── Fakes (mirror test_desktop_mate.py so fixtures read consistently) ────────
 
 
 class FakeConnection:
@@ -75,6 +73,7 @@ class FakeConnection:
         async def _gen():
             for item in list(self.inbox):
                 yield item
+
         return _gen()
 
 
@@ -109,29 +108,31 @@ def _decode_frames(conn: FakeConnection) -> list[dict[str, Any]]:
     return [json.loads(raw) for raw in conn.sent]
 
 
-# ---------------------------------------------------------------------------
-# Protocol layer: images field on the inbound frames
-# ---------------------------------------------------------------------------
+# ── Protocol layer: images field on the inbound frames ───────────────────────
 
 
 def test_inbound_message_accepts_images_field() -> None:
-    raw = json.dumps({
-        "type": "message",
-        "chat_id": "chat-1",
-        "content": "see",
-        "images": [TINY_PNG_DATA_URL],
-    })
+    raw = json.dumps(
+        {
+            "type": "message",
+            "chat_id": "chat-1",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL],
+        }
+    )
     env = parse_inbound(raw)
     assert isinstance(env, MessageFrame)
     assert env.images == [TINY_PNG_DATA_URL]
 
 
 def test_inbound_new_chat_accepts_images_field() -> None:
-    raw = json.dumps({
-        "type": "new_chat",
-        "content": "see",
-        "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
-    })
+    raw = json.dumps(
+        {
+            "type": "new_chat",
+            "content": "see",
+            "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
+        }
+    )
     env = parse_inbound(raw)
     assert isinstance(env, NewChatFrame)
     assert env.images == [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL]
@@ -152,42 +153,48 @@ def test_inbound_images_schema_does_not_cap_count() -> None:
     learn the turn was rejected. Regression: make sure nobody reintroduces
     a schema-level cap.
     """
-    raw = json.dumps({
-        "type": "message",
-        "chat_id": "c-1",
-        "content": "hi",
-        "images": [TINY_PNG_DATA_URL] * 5,
-    })
+    raw = json.dumps(
+        {
+            "type": "message",
+            "chat_id": "c-1",
+            "content": "hi",
+            "images": [TINY_PNG_DATA_URL] * 5,
+        }
+    )
     env = parse_inbound(raw)
     assert isinstance(env, MessageFrame)
     assert env.images is not None and len(env.images) == 5
 
 
 def test_inbound_images_rejects_wrong_item_type() -> None:
-    raw = json.dumps({
-        "type": "message",
-        "chat_id": "c-1",
-        "content": "hi",
-        "images": [{"url": TINY_PNG_DATA_URL}],
-    })
+    raw = json.dumps(
+        {
+            "type": "message",
+            "chat_id": "c-1",
+            "content": "hi",
+            "images": [{"url": TINY_PNG_DATA_URL}],
+        }
+    )
     with pytest.raises(ValidationError):
         parse_inbound(raw)
 
 
-# ---------------------------------------------------------------------------
-# Channel wiring: happy path
-# ---------------------------------------------------------------------------
+# ── Channel wiring: happy path ───────────────────────────────────────────────
 
 
 async def test_single_valid_image_is_persisted_and_forwarded(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "new_chat",
-            "content": "describe",
-            "images": [TINY_PNG_DATA_URL],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "new_chat",
+                    "content": "describe",
+                    "images": [TINY_PNG_DATA_URL],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -202,14 +209,18 @@ async def test_single_valid_image_is_persisted_and_forwarded(tmp_path: Path) -> 
 
 async def test_multiple_valid_images_preserve_order(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL, TINY_JPG_DATA_URL],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -225,14 +236,18 @@ async def test_multiple_valid_images_preserve_order(tmp_path: Path) -> None:
 async def test_image_only_turn_accepted(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
     # content is blank-ish — allowed so long as at least one image rides along.
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": " ",  # whitespace-only
-            "images": [TINY_PNG_DATA_URL],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": " ",  # whitespace-only
+                    "images": [TINY_PNG_DATA_URL],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -243,9 +258,11 @@ async def test_image_only_turn_accepted(tmp_path: Path) -> None:
 async def test_images_absent_is_no_op(tmp_path: Path) -> None:
     """Regression: omitting ``images`` keeps the legacy text-only path."""
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi"}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi"}),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -258,9 +275,11 @@ async def test_images_absent_is_no_op(tmp_path: Path) -> None:
 
 async def test_images_null_is_no_op(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({"type": "new_chat", "content": "hi", "images": None}),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps({"type": "new_chat", "content": "hi", "images": None}),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -268,22 +287,24 @@ async def test_images_null_is_no_op(tmp_path: Path) -> None:
     assert bus.inbound[0].media == []
 
 
-# ---------------------------------------------------------------------------
-# Channel wiring: rejection paths
-# ---------------------------------------------------------------------------
+# ── Channel wiring: rejection paths ──────────────────────────────────────────
 
 
 async def test_malformed_data_url_rejected(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            # Missing the ``data:<mime>;base64,`` prefix — raw base64 only.
-            "images": [_TINY_PNG_B64],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    # Missing the ``data:<mime>;base64,`` prefix — raw base64 only.
+                    "images": [_TINY_PNG_B64],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -301,14 +322,18 @@ async def test_oversized_image_rejected(tmp_path: Path) -> None:
     channel._max_image_bytes = 32
     big_payload = base64.b64encode(b"X" * 256).decode("ascii")
     big_url = f"data:image/png;base64,{big_payload}"
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [big_url],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [big_url],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -321,14 +346,18 @@ async def test_oversized_image_rejected(tmp_path: Path) -> None:
 async def test_unsupported_mime_rejected(tmp_path: Path) -> None:
     channel, bus = _make_channel(tmp_path)
     svg_url = "data:image/svg+xml;base64," + base64.b64encode(b"<svg/>").decode()
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [svg_url],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [svg_url],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -346,14 +375,18 @@ async def test_too_many_images_emits_rejection_frame(tmp_path: Path) -> None:
     inbound loop's generic handler — leaving FE without any rejection.
     """
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL] * 5,
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL] * 5,
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -377,14 +410,18 @@ async def test_partial_ingress_cleanup_on_later_failure(tmp_path: Path) -> None:
     channel._max_image_bytes = 32
     oversized_payload = base64.b64encode(b"X" * 256).decode("ascii")
     oversized_url = f"data:image/png;base64,{oversized_payload}"
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL, oversized_url],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL, oversized_url],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -413,14 +450,18 @@ async def test_io_error_during_persist_surfaces_as_io_error(
         "nanobot_runtime.services.channels.desktop_mate_image.save_base64_data_url",
         _raise_oserror,
     )
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -438,14 +479,18 @@ async def test_reference_id_echoed_on_rejection(tmp_path: Path) -> None:
     has no way to match the rejection to an in-flight request.
     """
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "new_chat",
-            "content": "see",
-            "reference_id": "req-42",
-            "images": [_TINY_PNG_B64],  # missing data: prefix => malformed
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "new_chat",
+                    "content": "see",
+                    "reference_id": "req-42",
+                    "images": [_TINY_PNG_B64],  # missing data: prefix => malformed
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -464,14 +509,18 @@ async def test_exact_boundary_four_images_accepted(tmp_path: Path) -> None:
     over-cap test alone would not catch.
     """
     channel, bus = _make_channel(tmp_path)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL] * 4,
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL] * 4,
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 
@@ -497,14 +546,18 @@ async def test_decoded_media_unlinked_when_handle_message_raises(
         raise RuntimeError("bus publish failed (simulated)")
 
     monkeypatch.setattr(channel, "_handle_message", _raising_handle_message)
-    conn = FakeConnection(inbox=[
-        json.dumps({
-            "type": "message",
-            "chat_id": "chat-1",
-            "content": "see",
-            "images": [TINY_PNG_DATA_URL],
-        }),
-    ])
+    conn = FakeConnection(
+        inbox=[
+            json.dumps(
+                {
+                    "type": "message",
+                    "chat_id": "chat-1",
+                    "content": "see",
+                    "images": [TINY_PNG_DATA_URL],
+                }
+            ),
+        ]
+    )
 
     await channel._connection_loop(conn, sender_id="user-1")
 

--- a/tests/services/channels/test_gateway_sm_injection.py
+++ b/tests/services/channels/test_gateway_sm_injection.py
@@ -7,13 +7,12 @@ declares the kwarg — including ``desktop_mate``. This test verifies the
 patch actually takes effect by constructing a ``ChannelManager`` with a
 fake session manager and confirming the channel received it.
 """
+
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
 
 from nanobot_runtime.services.channels.desktop_mate import DesktopMateChannel
 from nanobot_runtime.gateway import _install_channel_manager_patch
@@ -63,9 +62,9 @@ def test_gateway_patch_injects_session_manager_into_desktop_mate():
     mgr = ChannelManager(config, _FakeBus(), session_manager=fake_sm)
 
     channel = mgr.channels.get("desktop_mate")
-    assert isinstance(channel, DesktopMateChannel), (
-        "desktop_mate channel did not initialise; patch may have regressed"
-    )
-    assert channel._session_manager is fake_sm, (
-        "gateway patch failed to inject session_manager into DesktopMateChannel"
-    )
+    assert isinstance(
+        channel, DesktopMateChannel
+    ), "desktop_mate channel did not initialise; patch may have regressed"
+    assert (
+        channel._session_manager is fake_sm
+    ), "gateway patch failed to inject session_manager into DesktopMateChannel"

--- a/tests/services/channels/test_integration.py
+++ b/tests/services/channels/test_integration.py
@@ -4,6 +4,7 @@ These tests verify the three points where our code meets nanobot's
 installed package — if any of them break, the gateway won't start and
 silent failure is likely. Run once per environment change.
 """
+
 from __future__ import annotations
 
 from importlib.metadata import entry_points
@@ -36,16 +37,18 @@ def test_channels_config_preserves_desktop_mate_section_as_dict():
     """
     from nanobot.config.schema import ChannelsConfig
 
-    cfg = ChannelsConfig.model_validate({
-        "desktop_mate": {
-            "enabled": True,
-            "host": "127.0.0.1",
-            "port": 8765,
-            "allowFrom": ["*"],
-            "pingIntervalS": 15.0,
-            "maxMessageBytes": 4_000_000,
+    cfg = ChannelsConfig.model_validate(
+        {
+            "desktop_mate": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 8765,
+                "allowFrom": ["*"],
+                "pingIntervalS": 15.0,
+                "maxMessageBytes": 4_000_000,
+            }
         }
-    })
+    )
 
     section = getattr(cfg, "desktop_mate")
     assert isinstance(section, dict)

--- a/tests/services/channels/test_tts_sink_wiring.py
+++ b/tests/services/channels/test_tts_sink_wiring.py
@@ -5,6 +5,7 @@ DesktopMateChannel is a singleton created by nanobot's ChannelManager on
 a separate code path. This shim resolves the channel on-demand so the
 two construction orders don't have to be coordinated.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -41,9 +42,7 @@ def setup_function(_fn):
     _reset_registry_for_tests()
 
 
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
+# ── Registry ─────────────────────────────────────────────────────────────────
 
 
 def test_get_channel_raises_before_any_instance_created():
@@ -64,9 +63,7 @@ def test_latest_channel_overrides_previous():
     assert first is not second
 
 
-# ---------------------------------------------------------------------------
-# Lazy TTS sink
-# ---------------------------------------------------------------------------
+# ── Lazy TTS sink ────────────────────────────────────────────────────────────
 
 
 async def test_lazy_sink_drops_chunk_when_channel_absent(caplog):
@@ -155,15 +152,18 @@ async def test_lazy_sink_forwards_to_registered_channel():
     channel._current_stream_id = "s-1"
 
     sink = LazyChannelTTSSink(mode_map=_streaming_map())
-    await sink.send_tts_chunk(TTSChunk(
-        sequence=3,
-        text="hello",
-        audio_base64="QUJDRA==",
-        emotion="happy",
-        keyframes=[],
-    ))
+    await sink.send_tts_chunk(
+        TTSChunk(
+            sequence=3,
+            text="hello",
+            audio_base64="QUJDRA==",
+            emotion="happy",
+            keyframes=[],
+        )
+    )
 
     import json
+
     assert len(conn.sent) == 1
     frame = json.loads(conn.sent[0])
     assert frame["event"] == "tts_chunk"

--- a/tests/services/hooks/ltm/test_args.py
+++ b/tests/services/hooks/ltm/test_args.py
@@ -1,4 +1,5 @@
 """Tests for LTMArgumentsHook — overrides user_id/agent_id on mcp_ltm_* calls."""
+
 from __future__ import annotations
 
 from nanobot.agent.hook import AgentHookContext

--- a/tests/services/hooks/ltm/test_consolidator.py
+++ b/tests/services/hooks/ltm/test_consolidator.py
@@ -1,6 +1,7 @@
 """Tests for LTMSavingConsolidator — wraps nanobot Consolidator to push
 archived conversation turns (summary + raw user turns) into LTM.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -75,13 +76,15 @@ async def test_archive_pushes_user_turns_but_skips_assistant_and_tool() -> None:
     ltm = _FakeLTM()
     wrapper = LTMSavingConsolidator(inner, ltm, user_id="u1")
 
-    await wrapper.archive([
-        {"role": "user", "content": "I like coffee"},
-        {"role": "assistant", "content": "noted"},
-        {"role": "user", "content": "also tea"},
-        {"role": "tool", "content": "{}"},
-        {"role": "system", "content": "ignore this"},
-    ])
+    await wrapper.archive(
+        [
+            {"role": "user", "content": "I like coffee"},
+            {"role": "assistant", "content": "noted"},
+            {"role": "user", "content": "also tea"},
+            {"role": "tool", "content": "{}"},
+            {"role": "system", "content": "ignore this"},
+        ]
+    )
 
     contents = [c["content"] for c in ltm.add_calls]
     assert "I like coffee" in contents
@@ -130,12 +133,14 @@ async def test_archive_skips_empty_user_content() -> None:
     ltm = _FakeLTM()
     wrapper = LTMSavingConsolidator(inner, ltm, user_id="u1")
 
-    await wrapper.archive([
-        {"role": "user", "content": ""},
-        {"role": "user", "content": None},
-        {"role": "user"},  # missing content key
-        {"role": "user", "content": "keep"},
-    ])
+    await wrapper.archive(
+        [
+            {"role": "user", "content": ""},
+            {"role": "user", "content": None},
+            {"role": "user"},  # missing content key
+            {"role": "user", "content": "keep"},
+        ]
+    )
 
     contents = [c["content"] for c in ltm.add_calls]
     # summary is always pushed when non-empty; user turns only include "keep"

--- a/tests/services/hooks/ltm/test_injection.py
+++ b/tests/services/hooks/ltm/test_injection.py
@@ -3,6 +3,7 @@
 Hook injects relevant long-term memories into the system prompt before the
 first LLM call of each user turn.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
@@ -12,7 +13,9 @@ from nanobot.agent.hook import AgentHookContext
 from nanobot_runtime.services.hooks.ltm.injection import LTMInjectionHook
 
 
-async def test_before_iteration_searches_last_user_message_and_injects_into_system_prompt() -> None:
+async def test_before_iteration_searches_last_user_message_and_injects_into_system_prompt() -> (
+    None
+):
     ltm = AsyncMock()
     ltm.search_memory.return_value = {
         "results": [
@@ -116,9 +119,7 @@ async def test_skips_injection_when_backend_returns_error() -> None:
 async def test_agent_id_is_forwarded_when_set() -> None:
     ltm = AsyncMock()
     ltm.search_memory.return_value = {"results": []}
-    hook = LTMInjectionHook(
-        ltm_client=ltm, user_id="sangjun", agent_id="yuri", limit=3
-    )
+    hook = LTMInjectionHook(ltm_client=ltm, user_id="sangjun", agent_id="yuri", limit=3)
 
     ctx = AgentHookContext(
         iteration=0,
@@ -165,9 +166,7 @@ async def test_double_fire_at_iteration_zero_is_idempotent() -> None:
 async def test_prepends_system_message_when_none_exists() -> None:
     """If no system message is present, hook should create one with the memories."""
     ltm = AsyncMock()
-    ltm.search_memory.return_value = {
-        "results": [{"id": "m1", "memory": "fact one"}]
-    }
+    ltm.search_memory.return_value = {"results": [{"id": "m1", "memory": "fact one"}]}
     hook = LTMInjectionHook(ltm_client=ltm, user_id="sangjun")
 
     ctx = AgentHookContext(

--- a/tests/services/hooks/tts/test_hook.py
+++ b/tests/services/hooks/tts/test_hook.py
@@ -2,7 +2,6 @@
 boundaries, synthesizes audio per boundary, emits tts_chunk events via an
 injected sink, and on stream_end blocks until all in-flight syntheses
 complete (TTS Barrier semantic)."""
-from __future__ import annotations
 
 import asyncio
 from typing import Any
@@ -13,9 +12,7 @@ from nanobot.agent.hook import AgentHookContext
 from nanobot_runtime.services.hooks.tts import TTSChunk, TTSHook, TTSSink
 
 
-# --------------------------------------------------------------------------
-# Fakes
-# --------------------------------------------------------------------------
+# ── Fakes ─────────────────────────────────────────────────────────────────────
 
 
 class _FakeChunker:
@@ -76,7 +73,9 @@ class _FakeSynthesizer:
         self._latency = latency
         self._fail_on = fail_on or set()
 
-    async def synthesize(self, text: str, *, reference_id: str | None = None) -> str | None:
+    async def synthesize(
+        self, text: str, *, reference_id: str | None = None
+    ) -> str | None:
         if self._latency:
             await asyncio.sleep(self._latency)
         self.calls.append(text)
@@ -137,14 +136,10 @@ def _make_hook(
 
 
 def _ctx(iteration: int = 0, session_key: str = "test-session") -> AgentHookContext:
-    return AgentHookContext(
-        iteration=iteration, messages=[], session_key=session_key
-    )
+    return AgentHookContext(iteration=iteration, messages=[], session_key=session_key)
 
 
-# --------------------------------------------------------------------------
-# Tests
-# --------------------------------------------------------------------------
+# ── Tests ─────────────────────────────────────────────────────────────────────
 
 
 async def test_wants_streaming_is_true() -> None:
@@ -303,16 +298,16 @@ async def test_sequence_resets_per_hook_instance_across_turns() -> None:
     await hook.on_stream(ctx2, "Turn two. Done.")
     await hook.on_stream_end(ctx2, resuming=False)
 
-    first_turn = [c for c in sink.chunks if "Turn one" in c.text or c.text == "Done."][:2]
+    first_turn = [c for c in sink.chunks if "Turn one" in c.text or c.text == "Done."][
+        :2
+    ]
     second_turn_chunks = sink.chunks[len(first_turn) :]
 
     # Second turn's sequence starts at 0 again
     assert second_turn_chunks[0].sequence == 0
 
 
-# --------------------------------------------------------------------------
-# TTSSink.is_enabled — synthesis-skip path
-# --------------------------------------------------------------------------
+# ── TTSSink.is_enabled — synthesis-skip path ──────────────────────────────────
 
 
 class _FakeSinkWithEnableFlag(TTSSink):
@@ -349,7 +344,9 @@ async def test_is_enabled_false_skips_synthesis_entirely() -> None:
     await hook.on_stream(ctx, "Hello there.")
     await hook.on_stream_end(ctx, resuming=False)
 
-    assert synth.calls == [], f"synthesizer must not be called when disabled; got {synth.calls}"
+    assert (
+        synth.calls == []
+    ), f"synthesizer must not be called when disabled; got {synth.calls}"
     assert sink.chunks == [], f"no chunk should have been emitted; got {sink.chunks}"
 
 
@@ -371,9 +368,7 @@ async def test_is_enabled_true_keeps_default_behaviour() -> None:
     assert len(sink.chunks) == 1
 
 
-# --------------------------------------------------------------------------
-# reference_id resolver
-# --------------------------------------------------------------------------
+# ── reference_id resolver ─────────────────────────────────────────────────────
 
 
 async def test_reference_id_resolver_passes_voice_to_synthesizer() -> None:
@@ -455,7 +450,7 @@ async def test_no_resolver_passes_none_to_synthesize() -> None:
     assert synth.ref_calls == [None]
 
 
-# ── session_key plumbing into sink.is_enabled ─────────────────────────
+# ── session_key plumbing into sink.is_enabled ─────────────────────────────────
 
 
 async def test_dispatch_sentence_passes_session_key_to_is_enabled() -> None:
@@ -482,7 +477,9 @@ async def test_dispatch_sentence_passes_session_key_to_is_enabled() -> None:
     assert sink.is_enabled_calls == ["slack:C123:T456", "slack:C123:T456"]
 
 
-async def test_disabled_sink_skips_dispatch_no_synth_no_chunk_no_sequence_bump() -> None:
+async def test_disabled_sink_skips_dispatch_no_synth_no_chunk_no_sequence_bump() -> (
+    None
+):
     """When the sink reports disabled at dispatch time, the hook must
     skip synthesis entirely: no synth call, no emitted chunk, and the
     per-session sequence counter must not advance (so the next enabled
@@ -516,6 +513,7 @@ async def test_second_chance_check_skips_synth_when_sink_flips_after_dispatch() 
     synthesis entirely. Defends the line in `_synth_and_emit` that exists
     purely for this race.
     """
+
     class _FlipAfterDispatchSink(TTSSink):
         def __init__(self) -> None:
             self.chunks: list[TTSChunk] = []
@@ -558,6 +556,7 @@ def test_abc_rejects_sink_missing_required_methods() -> None:
     `is_enabled` and the hook would `AttributeError` at the dispatch
     hot path instead of failing loud at boot.
     """
+
     class _MissingIsEnabled(TTSSink):
         async def send_tts_chunk(self, chunk: TTSChunk) -> None:
             pass

--- a/tests/services/proactive/test_idle.py
+++ b/tests/services/proactive/test_idle.py
@@ -7,10 +7,10 @@ threshold, active-turn, cooldown, re-validation race) and the composite
 on_job wrapper used to install the system job without clobbering any
 existing cron callback.
 """
+
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -53,7 +53,11 @@ def _iso_ago(now: datetime, seconds: int) -> str:
 
 
 def _session_info(key: str, now: datetime, age_s: int) -> dict:
-    return {"key": key, "updated_at": _iso_ago(now, age_s), "created_at": _iso_ago(now, age_s + 10)}
+    return {
+        "key": key,
+        "updated_at": _iso_ago(now, age_s),
+        "created_at": _iso_ago(now, age_s + 10),
+    }
 
 
 def _fake_session(updated_at: datetime) -> SimpleNamespace:
@@ -70,13 +74,17 @@ def _build_agent(locks: dict | None = None) -> MagicMock:
     return agent
 
 
-def _build_sessions(list_result: list[dict], fresh_by_key: dict | None = None) -> MagicMock:
+def _build_sessions(
+    list_result: list[dict], fresh_by_key: dict | None = None
+) -> MagicMock:
     sessions = MagicMock()
     sessions.list_sessions.return_value = list_result
     fresh_by_key = fresh_by_key or {}
 
     def _get_or_create(key: str):
-        return fresh_by_key.get(key) or _fake_session(datetime.fromisoformat(list_result[0]["updated_at"]))
+        return fresh_by_key.get(key) or _fake_session(
+            datetime.fromisoformat(list_result[0]["updated_at"])
+        )
 
     sessions.get_or_create.side_effect = _get_or_create
     return sessions
@@ -92,7 +100,9 @@ async def test_in_quiet_hours_suppresses_nudge() -> None:
     agent = _build_agent()
     sessions = _build_sessions([_session_info("desktop_mate:abc", now, age_s=3600)])
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_not_called()
@@ -102,17 +112,29 @@ async def test_quiet_hours_spanning_midnight() -> None:
     """22:00-06:00 should treat 03:00 as quiet and 08:00 as non-quiet."""
     config = _cfg(quiet_hours=QuietHours(start="22:00", end="06:00"))
     agent = _build_agent()
-    sessions = _build_sessions([_session_info("desktop_mate:abc", datetime(2026, 4, 22, 3, 0, tzinfo=_TZ), age_s=3600)])
+    sessions = _build_sessions(
+        [
+            _session_info(
+                "desktop_mate:abc", datetime(2026, 4, 22, 3, 0, tzinfo=_TZ), age_s=3600
+            )
+        ]
+    )
 
     quiet_now = datetime(2026, 4, 22, 3, 0, tzinfo=_TZ)
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: quiet_now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: quiet_now
+    )
     await scanner.scan_and_nudge()
     agent.bus.publish_inbound.assert_not_called()
 
     # Same session but now 08:00 — quiet hours over.
     wake_now = datetime(2026, 4, 22, 8, 0, tzinfo=_TZ)
-    sessions = _build_sessions([_session_info("desktop_mate:abc", wake_now, age_s=3600)])
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: wake_now)
+    sessions = _build_sessions(
+        [_session_info("desktop_mate:abc", wake_now, age_s=3600)]
+    )
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: wake_now
+    )
     await scanner.scan_and_nudge()
     agent.bus.publish_inbound.assert_awaited_once()
 
@@ -124,7 +146,9 @@ async def test_idle_below_threshold_skipped() -> None:
     # Last message 60s ago — below 300s threshold.
     sessions = _build_sessions([_session_info("desktop_mate:abc", now, age_s=60)])
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_not_called()
@@ -139,7 +163,9 @@ async def test_active_turn_skipped() -> None:
         agent = _build_agent(locks={"desktop_mate:abc": locked})
         sessions = _build_sessions([_session_info("desktop_mate:abc", now, age_s=3600)])
 
-        scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+        scanner = IdleScanner(
+            agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now
+        )
         await scanner.scan_and_nudge()
 
         agent.bus.publish_inbound.assert_not_called()
@@ -158,14 +184,20 @@ async def test_cooldown_blocks_second_nudge() -> None:
         fresh_by_key={"desktop_mate:abc": fresh},
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
     assert agent.bus.publish_inbound.await_count == 1
 
     # 5 minutes later — still within cooldown; idle threshold still satisfied.
     later = now + timedelta(seconds=300)
-    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", later, age_s=3900)]
-    sessions.get_or_create.side_effect = lambda _k: _fake_session(later - timedelta(seconds=3900))
+    sessions.list_sessions.return_value = [
+        _session_info("desktop_mate:abc", later, age_s=3900)
+    ]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(
+        later - timedelta(seconds=3900)
+    )
     scanner._clock = lambda: later
     await scanner.scan_and_nudge()
     assert agent.bus.publish_inbound.await_count == 1  # unchanged due to cooldown
@@ -180,14 +212,20 @@ async def test_cooldown_expired_allows_second_nudge() -> None:
         fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=3600))},
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
     assert agent.bus.publish_inbound.await_count == 1
 
     # 16 minutes later — cooldown window past, session still idle.
     later = now + timedelta(seconds=16 * 60)
-    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", later, age_s=3600 + 16 * 60)]
-    sessions.get_or_create.side_effect = lambda _k: _fake_session(later - timedelta(seconds=3600 + 16 * 60))
+    sessions.list_sessions.return_value = [
+        _session_info("desktop_mate:abc", later, age_s=3600 + 16 * 60)
+    ]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(
+        later - timedelta(seconds=3600 + 16 * 60)
+    )
     scanner._clock = lambda: later
     await scanner.scan_and_nudge()
     assert agent.bus.publish_inbound.await_count == 2  # cooldown expired
@@ -200,7 +238,9 @@ async def test_channel_not_in_allowlist_skipped() -> None:
     agent = _build_agent()
     sessions = _build_sessions([_session_info("slack:C012:1234", now, age_s=3600)])
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_not_called()
@@ -210,12 +250,16 @@ async def test_session_key_without_colon_skipped() -> None:
     """Malformed keys (e.g. 'cli', 'heartbeat') are not routable — skip safely."""
     now = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
     agent = _build_agent()
-    sessions = _build_sessions([
-        _session_info("heartbeat", now, age_s=3600),
-        _session_info("cli", now, age_s=3600),
-    ])
+    sessions = _build_sessions(
+        [
+            _session_info("heartbeat", now, age_s=3600),
+            _session_info("cli", now, age_s=3600),
+        ]
+    )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_not_called()
@@ -231,7 +275,9 @@ async def test_revalidation_race_skipped() -> None:
         fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=10))},
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_not_called()
@@ -243,10 +289,14 @@ async def test_all_gates_pass_publishes_inbound_with_correct_target() -> None:
     agent = _build_agent()
     sessions = _build_sessions(
         [_session_info("desktop_mate:chat-abc", now, age_s=600)],
-        fresh_by_key={"desktop_mate:chat-abc": _fake_session(now - timedelta(seconds=600))},
+        fresh_by_key={
+            "desktop_mate:chat-abc": _fake_session(now - timedelta(seconds=600))
+        },
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=config, clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=config, clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_awaited_once()
@@ -267,7 +317,9 @@ async def test_publish_inbound_exception_swallowed_and_cooldown_preserved() -> N
         fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=3600))},
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(cooldown_s=900), clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(cooldown_s=900), clock=lambda: now
+    )
     await scanner.scan_and_nudge()  # must not raise
 
     # Second tick in same minute — cooldown still marked so no retry storm.
@@ -320,7 +372,9 @@ async def test_install_disabled_config_is_noop() -> None:
     sentinel = AsyncMock()
     cron.on_job = sentinel
 
-    install_idle_system_job(agent=agent, sessions=sessions, cron=cron, config=_cfg(enabled=False))
+    install_idle_system_job(
+        agent=agent, sessions=sessions, cron=cron, config=_cfg(enabled=False)
+    )
 
     cron.register_system_job.assert_not_called()
     assert cron.on_job is sentinel  # untouched
@@ -387,9 +441,9 @@ async def test_only_most_recent_session_nudged_when_multiple_idle() -> None:
     agent = _build_agent()
     sessions = _build_sessions(
         [
-            _session_info("desktop_mate:older", now, age_s=7200),    # 2h idle
-            _session_info("desktop_mate:recent", now, age_s=600),    # 10m idle (winner)
-            _session_info("desktop_mate:middling", now, age_s=3600), # 1h idle
+            _session_info("desktop_mate:older", now, age_s=7200),  # 2h idle
+            _session_info("desktop_mate:recent", now, age_s=600),  # 10m idle (winner)
+            _session_info("desktop_mate:middling", now, age_s=3600),  # 1h idle
         ],
         fresh_by_key={
             "desktop_mate:older": _fake_session(now - timedelta(seconds=7200)),
@@ -398,7 +452,9 @@ async def test_only_most_recent_session_nudged_when_multiple_idle() -> None:
         },
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_awaited_once()
@@ -415,27 +471,42 @@ async def test_startup_grace_suppresses_nudge_then_releases() -> None:
     """
     boot = datetime(2026, 4, 22, 14, 0, tzinfo=_TZ)
     cursor = {"now": boot}
-    clock = lambda: cursor["now"]
+
+    def clock():
+        return cursor["now"]
+
     agent = _build_agent()
     sessions = _build_sessions(
         [_session_info("desktop_mate:abc", boot, age_s=3600)],
-        fresh_by_key={"desktop_mate:abc": _fake_session(boot - timedelta(seconds=3600))},
+        fresh_by_key={
+            "desktop_mate:abc": _fake_session(boot - timedelta(seconds=3600))
+        },
     )
 
     # _started_at captured at __init__ via clock()
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(startup_grace_s=120), clock=clock)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(startup_grace_s=120), clock=clock
+    )
 
     # Tick 30s after boot — within grace, must skip.
     cursor["now"] = boot + timedelta(seconds=30)
-    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", cursor["now"], age_s=3630)]
-    sessions.get_or_create.side_effect = lambda _k: _fake_session(cursor["now"] - timedelta(seconds=3630))
+    sessions.list_sessions.return_value = [
+        _session_info("desktop_mate:abc", cursor["now"], age_s=3630)
+    ]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(
+        cursor["now"] - timedelta(seconds=3630)
+    )
     await scanner.scan_and_nudge()
     agent.bus.publish_inbound.assert_not_called()
 
     # Tick 121s after boot — grace expired, idle gates pass, must dispatch.
     cursor["now"] = boot + timedelta(seconds=121)
-    sessions.list_sessions.return_value = [_session_info("desktop_mate:abc", cursor["now"], age_s=3721)]
-    sessions.get_or_create.side_effect = lambda _k: _fake_session(cursor["now"] - timedelta(seconds=3721))
+    sessions.list_sessions.return_value = [
+        _session_info("desktop_mate:abc", cursor["now"], age_s=3721)
+    ]
+    sessions.get_or_create.side_effect = lambda _k: _fake_session(
+        cursor["now"] - timedelta(seconds=3721)
+    )
     await scanner.scan_and_nudge()
     agent.bus.publish_inbound.assert_awaited_once()
 
@@ -455,7 +526,9 @@ async def test_published_inbound_carries_proactive_and_wants_stream() -> None:
         fresh_by_key={"desktop_mate:abc": _fake_session(now - timedelta(seconds=600))},
     )
 
-    scanner = IdleScanner(agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now)
+    scanner = IdleScanner(
+        agent=agent, sessions=sessions, config=_cfg(), clock=lambda: now
+    )
     await scanner.scan_and_nudge()
 
     agent.bus.publish_inbound.assert_awaited_once()
@@ -481,7 +554,9 @@ async def test_asyncio_install_disabled_is_noop() -> None:
     agent = SimpleNamespace(_session_locks={}, bus=MagicMock())
     sessions = _build_sessions([])
 
-    result = install_idle_asyncio_task(agent=agent, sessions=sessions, config=_cfg(enabled=False))
+    result = install_idle_asyncio_task(
+        agent=agent, sessions=sessions, config=_cfg(enabled=False)
+    )
 
     assert result is None
     assert not hasattr(agent, IDLE_ASYNCIO_TASK_ATTR)

--- a/tests/services/proactive/test_idle_integration.py
+++ b/tests/services/proactive/test_idle_integration.py
@@ -5,6 +5,7 @@ This test plugs :func:`install_idle_system_job` into a real
 ``CronService`` to prove the glue registers, fires, and routes correctly
 without a gateway subprocess.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -13,13 +14,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from zoneinfo import ZoneInfo
 
-import pytest
 from nanobot.cron.service import CronService
-from nanobot.cron.types import CronJob, CronPayload, CronSchedule
+from nanobot.cron.types import CronJob, CronSchedule
 
 from nanobot_runtime.config.idle import IdleConfig
 from nanobot_runtime.services.proactive.installer import (
-    IDLE_SYSTEM_JOB_ID,
     install_idle_system_job,
 )
 
@@ -34,7 +33,10 @@ async def test_real_cron_fires_scanner_and_nudges_idle_session(tmp_path) -> None
 
     sessions = MagicMock()
     sessions.list_sessions.return_value = [
-        {"key": "desktop_mate:abc", "updated_at": (now - timedelta(seconds=3600)).isoformat()},
+        {
+            "key": "desktop_mate:abc",
+            "updated_at": (now - timedelta(seconds=3600)).isoformat(),
+        },
     ]
     sessions.get_or_create.return_value = SimpleNamespace(
         updated_at=now - timedelta(seconds=3600),
@@ -88,7 +90,9 @@ async def test_real_cron_preserves_existing_on_job(tmp_path) -> None:
         idle_agent.bus.publish_inbound = AsyncMock()
         install_idle_system_job(
             agent=idle_agent,
-            sessions=MagicMock(list_sessions=MagicMock(return_value=[]), get_or_create=MagicMock()),
+            sessions=MagicMock(
+                list_sessions=MagicMock(return_value=[]), get_or_create=MagicMock()
+            ),
             cron=cron,
             config=IdleConfig(
                 enabled=True,

--- a/tests/services/tts/test_chunker.py
+++ b/tests/services/tts/test_chunker.py
@@ -2,6 +2,7 @@
 into sentence-terminated chunks, filters <think> reasoning blocks, and
 yields a remainder on flush().
 """
+
 from __future__ import annotations
 
 from nanobot_runtime.services.tts.chunker import SentenceChunker

--- a/tests/services/tts/test_emotion_mapper.py
+++ b/tests/services/tts/test_emotion_mapper.py
@@ -1,4 +1,5 @@
 """Tests for EmotionMapper — map emotion string/emoji → keyframe list."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/services/tts/test_modes.py
+++ b/tests/services/tts/test_modes.py
@@ -5,6 +5,7 @@ the loader's failure modes (which surface as boot-time ValueErrors), and
 the map's lookup semantics (None / unknown channel both fall through to
 the configured default).
 """
+
 from pathlib import Path
 from typing import Callable
 
@@ -63,13 +64,18 @@ class TestChannelModeMapLookup:
     def test_known_channel_returns_mapped_mode(self):
         m = ChannelModeMap(
             default=TTSMode.NONE,
-            channels={"desktop_mate": TTSMode.STREAMING, "telegram": TTSMode.ATTACHMENT},
+            channels={
+                "desktop_mate": TTSMode.STREAMING,
+                "telegram": TTSMode.ATTACHMENT,
+            },
         )
         assert m.lookup("desktop_mate") is TTSMode.STREAMING
         assert m.lookup("telegram") is TTSMode.ATTACHMENT
 
     def test_unknown_channel_returns_default(self):
-        m = ChannelModeMap(default=TTSMode.NONE, channels={"desktop_mate": TTSMode.STREAMING})
+        m = ChannelModeMap(
+            default=TTSMode.NONE, channels={"desktop_mate": TTSMode.STREAMING}
+        )
         assert m.lookup("slack") is TTSMode.NONE
 
     def test_none_returns_default(self):
@@ -146,7 +152,9 @@ class TestLoadChannelModes:
         assert "default" in msg
         assert str(p) in msg
 
-    def test_unknown_channel_mode_raises_value_error_with_channel_name(self, tmp_path: Path):
+    def test_unknown_channel_mode_raises_value_error_with_channel_name(
+        self, tmp_path: Path
+    ):
         p = tmp_path / "modes.yml"
         p.write_text("channels:\n  telegram: brodcast\n")
         with pytest.raises(ValueError) as ei:

--- a/tests/services/tts/test_preprocessor.py
+++ b/tests/services/tts/test_preprocessor.py
@@ -1,6 +1,7 @@
 """Tests for Preprocessor — strip stage directions / meta brackets,
 normalize whitespace, and extract first known emotion emoji as tag.
 """
+
 from __future__ import annotations
 
 from nanobot_runtime.services.tts.preprocessor import Preprocessor

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -6,6 +6,7 @@ cover the pure-logic env-var parsing in ``_build_idle_config`` and
 strings, comma-list edge cases) and would otherwise only surface as
 mis-scheduled crons or missing TTS rules at startup.
 """
+
 import os
 
 import pytest
@@ -75,7 +76,8 @@ def test_idle_config_int_envvar_typo_surfaces_as_value_error(
 
 
 def test_tts_rules_path_defaults_to_cwd_resources(
-    monkeypatch: pytest.MonkeyPatch, tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     monkeypatch.chdir(tmp_path)
     expected = str(tmp_path / "resources" / "tts_rules.yml")
@@ -96,12 +98,14 @@ class TestResolveTtsModesPath:
     ):
         monkeypatch.chdir(tmp_path)
         from nanobot_runtime.launcher import _resolve_tts_modes_path
+
         expected = str(tmp_path / "resources" / "tts_channel_modes.yml")
         assert _resolve_tts_modes_path() == expected
 
     def test_modes_path_env_override_wins(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("TTS_MODES_PATH", "/tmp/custom_modes.yml")
         from nanobot_runtime.launcher import _resolve_tts_modes_path
+
         assert _resolve_tts_modes_path() == "/tmp/custom_modes.yml"
 
 
@@ -120,6 +124,7 @@ class TestBuildTtsHookFailsWhenModesMissing:
         monkeypatch.setenv("TTS_MODES_PATH", str(tmp_path / "missing.yml"))
 
         from nanobot_runtime.launcher import _build_tts_hook
+
         with pytest.raises(FileNotFoundError) as ei:
             _build_tts_hook()
         msg = str(ei.value)
@@ -138,6 +143,7 @@ class TestBuildTtsHookFailsWhenModesMissing:
         monkeypatch.setenv("TTS_MODES_PATH", str(tmp_path / "missing_modes.yml"))
 
         from nanobot_runtime.launcher import _build_tts_hook
+
         with pytest.raises(FileNotFoundError) as ei:
             _build_tts_hook()
         msg = str(ei.value)
@@ -172,6 +178,7 @@ class TestBuildTtsHookFailsWhenModesMissing:
 
         from unittest.mock import MagicMock
         from nanobot_runtime.launcher import _hooks_factory
+
         loop = MagicMock()
         loop.cron_service = None  # not consulted because IDLE is off
 


### PR DESCRIPTION
## Summary

- Adds `scripts/check_antipatterns.py` — AST + regex checker for CODING_RULES violations ruff/black cannot detect (traceback loss in except blocks, stdlib logging, `asyncio.gather(return_exceptions=True)` as silence, `# ---` section comment style); integrated into `scripts/lint.sh`
- Refactors `services/hooks/tts.py` into a `hooks/tts/` package (`models.py`, `abc.py`, `protocols.py`, `hook.py`, `__init__.py`) — all existing import paths unchanged; also replaces `asyncio.wait_for(gather(return_exceptions=True))` with `asyncio.wait()` in the TTS Barrier
- Fixes anti-pattern violations found by the new checker across `src/` (traceback-loss in 5 files, `asyncio.gather` in `ltm/consolidator.py`), converts test section dividers to unicode style, and adds GitHub Actions CI

## Runtime component(s) touched

- [x] `TTSHook` (now `hooks/tts/` package)
- [x] TTS dependency impl (chunker / preprocessor / emotion mapper / synthesizer)
- [x] `LTMInjectionHook` / `LTMArgumentsHook` / `LTMSavingConsolidator`
- [x] Tests (unit / integration / e2e)
- [x] CI / tooling / dependencies

## nanobot-ai compatibility

N/A — no upstream contact. No changes to `AgentHookContext`, `AgentLoop`, `Consolidator.archive`, or `ChannelManager` wiring. `TTSHook` public interface unchanged; `__init__.py` re-exports keep all import paths stable.

## Test plan

- [x] `uv run pytest` (unit + integration, `-m 'not e2e'`) — all green (22/22 TTS hook tests, full suite passes)
- [ ] `uv run pytest -m e2e` — not required, no live-infra surface changed
- [x] Manual smoke — ran `bash scripts/lint.sh` end-to-end: black/ruff clean, anti-pattern checker reports 0 violations

## Notes for reviewer

The anti-pattern checker (`scripts/check_antipatterns.py`) is the key new artifact — it gates every future lint run. Four rule categories enforced:

1. `logger.error()` / `logger.warning()` inside `except` blocks (use `logger.exception()` or `logger.opt(exception=True).warning()`)
2. `import logging` / stdlib logging usage
3. `asyncio.gather(return_exceptions=True)` without explicit result handling
4. `# ---` ASCII-dash section dividers (use `# ── Name ───` unicode style)

The `hooks/tts/` split follows the pattern established in the CODING_RULES update: ABC → `abc.py`, BaseModel → `models.py`, Protocols → `protocols.py`, implementation → `hook.py`.